### PR TITLE
Fix withoutUndefinedValues on query params

### DIFF
--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -14,6 +14,15 @@ const { generatedFilesDir, mockPort, isSpecEnabled } = config.specs.testapi;
 // if there's no need for this suite in this particular run, just skip it
 const describeSuite = skipClient || !isSpecEnabled ? describe.skip : describe;
 
+// given a spied fetch call, check if the request has been made using the provided parameter in querystring
+const hasQueryParam = (paramName: string) => ([input]: Parameters<
+  typeof fetch
+>) => {
+  const inputUrl = typeof input === "string" ? input : input.url;
+  const parsedUrl = url.parse(inputUrl);
+  return parsedUrl.query && ~parsedUrl.query.indexOf(paramName);
+};
+
 describeSuite("Http client generated from Test API spec", () => {
   it("should be a valid module", async () => {
     expect(createClient).toBeDefined();
@@ -95,14 +104,6 @@ describeSuite("Http client generated from Test API spec", () => {
   });
 
   it("should not edit parameter names", async () => {
-    // given a spied fetch call, check if the request has been made using the provided parameter in querystring
-    const hasQueryParam = (paramName: string) => ([input]: Parameters<
-      typeof fetch
-    >) => {
-      const inputUrl = typeof input === "string" ? input : input.url;
-      const parsedUrl = url.parse(inputUrl);
-      return parsedUrl.query && ~parsedUrl.query.indexOf(paramName);
-    };
 
     // given a spied fetch call, check if the request has been made using the provided header parameter
     const hasHeaderParam = (paramName: string) => ([, init]: Parameters<
@@ -151,15 +152,6 @@ describeSuite("Http client generated from Test API spec", () => {
   });
 
   it("should strip out undefined query params", async () => {
-    // given a spied fetch call, check if the request has been made using the provided parameter in querystring
-    const hasQueryParam = (paramName: string) => ([input]: Parameters<
-      typeof fetch
-    >) => {
-      const inputUrl = typeof input === "string" ? input : input.url;
-      const parsedUrl = url.parse(inputUrl);
-      return parsedUrl.query && ~parsedUrl.query.indexOf(paramName);
-    };
-
     const spiedFetch = jest.fn<
       ReturnType<typeof fetch>,
       Parameters<typeof fetch>

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -706,6 +706,7 @@ exports[`gen-api-models should render a client 1`] = `
  */
 /* eslint-disable  */
 
+import { withoutUndefinedValues } from \\"@pagopa/ts-commons/lib/types\\";
 import {
   RequestParams,
   TypeofApiCall,
@@ -944,11 +945,8 @@ export function createClient<K extends ParamKeys>({
     response_decoder: testAuthBearerDefaultDecoder(),
     url: ({}) => \`\${basePath}/test-auth-bearer\`,
 
-    query: ({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor }) => ({
-      [\\"qo\\"]: qo,
-      [\\"qr\\"]: qr,
-      [\\"cursor\\"]: cursor
-    })
+    query: ({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor }) =>
+      withoutUndefinedValues({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor })
   };
   const testAuthBearer: TypeofApiCall<TestAuthBearerT> = createFetchRequestForApi(
     testAuthBearerT,
@@ -967,11 +965,8 @@ export function createClient<K extends ParamKeys>({
     response_decoder: testSimpleTokenDefaultDecoder(),
     url: ({}) => \`\${basePath}/test-simple-token\`,
 
-    query: ({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor }) => ({
-      [\\"qo\\"]: qo,
-      [\\"qr\\"]: qr,
-      [\\"cursor\\"]: cursor
-    })
+    query: ({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor }) =>
+      withoutUndefinedValues({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor })
   };
   const testSimpleToken: TypeofApiCall<TestSimpleTokenT> = createFetchRequestForApi(
     testSimpleTokenT,
@@ -1078,10 +1073,8 @@ export function createClient<K extends ParamKeys>({
     url: ({ [\\"path-param\\"]: pathParam }) =>
       \`\${basePath}/test-parameter-with-dash/\${pathParam}\`,
 
-    query: ({ [\\"foo-bar\\"]: fooBar, [\\"request-id\\"]: requestId }) => ({
-      [\\"foo-bar\\"]: fooBar,
-      [\\"request-id\\"]: requestId
-    })
+    query: ({ [\\"foo-bar\\"]: fooBar, [\\"request-id\\"]: requestId }) =>
+      withoutUndefinedValues({ [\\"foo-bar\\"]: fooBar, [\\"request-id\\"]: requestId })
   };
   const testParameterWithDash: TypeofApiCall<TestParameterWithDashT> = createFetchRequestForApi(
     testParameterWithDashT,
@@ -1109,10 +1102,8 @@ export function createClient<K extends ParamKeys>({
     url: ({ [\\"path-param\\"]: pathParam }) =>
       \`\${basePath}/test-parameter-with-dash-and_underscore/\${pathParam}\`,
 
-    query: ({ [\\"foo_bar\\"]: fooBar, [\\"request-id\\"]: requestId }) => ({
-      [\\"foo_bar\\"]: fooBar,
-      [\\"request-id\\"]: requestId
-    })
+    query: ({ [\\"foo_bar\\"]: fooBar, [\\"request-id\\"]: requestId }) =>
+      withoutUndefinedValues({ [\\"foo_bar\\"]: fooBar, [\\"request-id\\"]: requestId })
   };
   const testParameterWithDashAnUnderscore: TypeofApiCall<TestParameterWithDashAnUnderscoreT> = createFetchRequestForApi(
     testParameterWithDashAnUnderscoreT,

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -6,6 +6,7 @@
  */
 /* eslint-disable  */
 
+import { withoutUndefinedValues } from "@pagopa/ts-commons/lib/types";
 import {
   RequestParams,
   TypeofApiCall,
@@ -145,7 +146,7 @@ export function createClient<K extends ParamKeys>({
     body: () => "{}",
     {% endif %}
     {% if queryParams | length %}
-    query: ({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(', ') | safe }} }) => ({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(", ") | safe  }} }),
+    query: ({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(', ') | safe }} }) => withoutUndefinedValues({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(", ") | safe  }} }),
     {% else %}
     query: () => ({}),
     {% endif %}


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
add wihoutUndefinedValues on QueryParams
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since query params are essentially strings we have to strip out all optional query params that could be possibly undefined. This can solve different issues while dealing with APIs that does not expect query param if they are not defined
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
