### PR TITLE
Fix command args type parsing

### DIFF
--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -1061,7 +1061,7 @@ export function createClient<K extends ParamKeys>({
     response_decoder: testMultipleSuccessDefaultDecoder(),
     url: ({}) => \`\${basePath}/test-multiple-success\`,
 
-    query: () => ({})
+    query: () => withoutUndefinedValues({})
   };
   const testMultipleSuccess: TypeofApiCall<TestMultipleSuccessT> = createFetchRequestForApi(
     testMultipleSuccessT,
@@ -1082,7 +1082,7 @@ export function createClient<K extends ParamKeys>({
 
     body: ({ [\\"file\\"]: file }) => file.uri,
 
-    query: () => ({})
+    query: () => withoutUndefinedValues({})
   };
   const testFileUpload: TypeofApiCall<TestFileUploadT> = createFetchRequestForApi(
     testFileUploadT,
@@ -1100,7 +1100,7 @@ export function createClient<K extends ParamKeys>({
     response_decoder: testResponseHeaderDefaultDecoder(),
     url: ({}) => \`\${basePath}/test-response-header\`,
 
-    query: () => ({})
+    query: () => withoutUndefinedValues({})
   };
   const testResponseHeader: TypeofApiCall<TestResponseHeaderT> = createFetchRequestForApi(
     testResponseHeaderT,
@@ -1122,7 +1122,7 @@ export function createClient<K extends ParamKeys>({
     body: ({ [\\"createdMessage\\"]: createdMessage }) =>
       JSON.stringify(createdMessage),
 
-    query: () => ({})
+    query: () => withoutUndefinedValues({})
   };
   const testParameterWithReference: TypeofApiCall<TestParameterWithReferenceT> = createFetchRequestForApi(
     testParameterWithReferenceT,
@@ -1199,7 +1199,7 @@ export function createClient<K extends ParamKeys>({
     url: ({ [\\"first-param\\"]: firstParam, [\\"second-param\\"]: secondParam }) =>
       \`\${basePath}/test-two-path-params/\${firstParam}/\${secondParam}\`,
 
-    query: () => ({})
+    query: () => withoutUndefinedValues({})
   };
   const testWithTwoParams: TypeofApiCall<TestWithTwoParamsT> = createFetchRequestForApi(
     testWithTwoParamsT,

--- a/src/commands/gen-api-models/cli.ts
+++ b/src/commands/gen-api-models/cli.ts
@@ -17,7 +17,7 @@ const argv = yargs
   })
   .option("strict", {
     // eslint-disable-next-line id-blacklist
-    boolean: false,
+    boolean: true,
     default: true,
     description: "Generate strict interfaces (default: true)"
   })
@@ -37,20 +37,20 @@ const argv = yargs
   })
   .option("request-types", {
     // eslint-disable-next-line id-blacklist
-    boolean: false,
+    boolean: true,
     default: false,
     description: "Generate request types (experimental, default: false)"
   })
   .option("response-decoders", {
     // eslint-disable-next-line id-blacklist
-    boolean: false,
+    boolean: true,
     default: false,
     description:
       "Generate response decoders (experimental, default: false, implies --request-types)"
   })
   .option("client", {
     // eslint-disable-next-line id-blacklist
-    boolean: false,
+    boolean: true,
     default: false,
     description: "Generate request client SDK"
   })
@@ -72,7 +72,7 @@ const argv = yargs
   })
   .option("camel-cased", {
     // eslint-disable-next-line id-blacklist
-    boolean: false,
+    boolean: true,
     default: false,
     description: "Generate camelCased properties name (default: false)"
   })

--- a/src/commands/gen-api-sdk/cli.ts
+++ b/src/commands/gen-api-sdk/cli.ts
@@ -104,7 +104,7 @@ const argv = yargs
   })
   .option("strict", {
     // eslint-disable-next-line id-blacklist
-    boolean: false,
+    boolean: true,
     default: true,
     description: "Generate strict interfaces (default: true)",
     group: CODE_GROUP
@@ -141,7 +141,7 @@ const argv = yargs
   })
   .option("camel-cased", {
     // eslint-disable-next-line id-blacklist
-    boolean: false,
+    boolean: true,
     default: false,
     description: "Generate camelCased properties name (default: false)",
     group: CODE_GROUP

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -148,7 +148,7 @@ export function createClient<K extends ParamKeys>({
     {% if queryParams | length %}
     query: ({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(', ') | safe }} }) => withoutUndefinedValues({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(", ") | safe  }} }),
     {% else %}
-    query: () => ({}),
+    query: () => withoutUndefinedValues({}),
     {% endif %}
   };
   const {{ operation.operationId }}: TypeofApiCall<{{ macro.requestTypeName(operation) }}> = createFetchRequestForApi({{ operation.operationId }}T, options);


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
Fix `yargs` option type
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After upgrading yargs to `"^15.0.1"`,  boolean command options with a default boolean value are not considered while running command.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
