### PR TITLE
[FIX] Fix client generation when custom header are defined

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -200,6 +200,28 @@ paths:
           description: "Ok"
         "500":
           description: "Fatal error"                    
+  /test-header-path-level-parameter:
+    parameters:
+      - $ref: "#/parameters/HeaderParamWithReference"
+    get:
+      operationId: "testHeaderParametersAtPathLevel"
+      description: when we declare parameters at path level
+      responses:
+        "200":  
+          description: "Ok"
+        "500":
+          description: "Fatal error"                    
+  /test-optional-header:
+    get:
+      operationId: "testOptionalHeaderParameters"
+      description: when we declare parameters at path level
+      parameters:
+        - $ref: "#/parameters/OptionalHeaderParamWithReference"
+      responses:
+        "200":  
+          description: "Ok"
+        "500":
+          description: "Fatal error"                    
 
 definitions:
   Person:
@@ -675,6 +697,12 @@ parameters:
     description: A header param which has dashes in it
     type: string
     required: true
+  OptionalHeaderParamWithReference:
+    name: x-header-param
+    in: header
+    description: A header param which has dashes in it
+    type: string
+    required: false
 consumes:
   - application/json
 produces:

--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -210,6 +210,59 @@ describeSuite("Http client generated from Test API spec", () => {
     });
   });
 
+  it("should handle header parameters at path level", async () => {
+    const spiedFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >((nodeFetch as any) as typeof fetch);
+
+    const client = createClient<"bearerToken">({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: spiedFetch,
+      basePath: "",
+      withDefaults: (op: any) => (params: any) =>
+        op({ ...params, bearerToken: "abc123" })
+    });
+
+    expect(client.testHeaderParametersAtPathLevel).toEqual(
+      expect.any(Function)
+    );
+
+    // It can be called with expected query parameters
+    const resultWithCursor = await client.testHeaderParametersAtPathLevel({
+      "x-header-param": "a value"
+    });
+
+    // It cannot be called without optional parameters
+    // @ts-expect-error
+    await client.testHeaderParametersAtPathLevel({});
+  });
+
+  it("should handle optional header parameters", async () => {
+    const spiedFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >((nodeFetch as any) as typeof fetch);
+
+    const client = createClient<"bearerToken">({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: spiedFetch,
+      basePath: "",
+      withDefaults: (op: any) => (params: any) =>
+        op({ ...params, bearerToken: "abc123" })
+    });
+
+    expect(client.testOptionalHeaderParameters).toEqual(expect.any(Function));
+
+    // It can be called with expected query parameters
+    await client.testOptionalHeaderParameters({
+      "x-header-param": "a value"
+    });
+
+    // It can be called without optional query parameters
+    await client.testOptionalHeaderParameters({});
+  });
+
   it("should raise an exception when calling file upload from ode runtime environment", async () => {
     const spiedFetch = jest.fn<
       ReturnType<typeof fetch>,

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -816,6 +816,8 @@ import {
   testWithTwoParamsDefaultDecoder,
   TestParametersAtPathLevelT,
   testParametersAtPathLevelDefaultDecoder,
+  TestHeaderParametersAtPathLevelT,
+  testHeaderParametersAtPathLevelDefaultDecoder,
   TestOptionalHeaderParametersT,
   testOptionalHeaderParametersDefaultDecoder
 } from \\"./requestTypes\\";
@@ -837,6 +839,7 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestParameterWithDashAnUnderscoreT> &
   TypeofApiCall<TestWithTwoParamsT> &
   TypeofApiCall<TestParametersAtPathLevelT> &
+  TypeofApiCall<TestHeaderParametersAtPathLevelT> &
   TypeofApiCall<TestOptionalHeaderParametersT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
@@ -850,6 +853,7 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestParameterWithDashAnUnderscoreT> &
   TypeofApiParams<TestWithTwoParamsT> &
   TypeofApiParams<TestParametersAtPathLevelT> &
+  TypeofApiParams<TestHeaderParametersAtPathLevelT> &
   TypeofApiParams<TestOptionalHeaderParametersT>);
 
 /**
@@ -885,6 +889,7 @@ export type WithDefaultsT<
   | TestParameterWithDashAnUnderscoreT
   | TestWithTwoParamsT
   | TestParametersAtPathLevelT
+  | TestHeaderParametersAtPathLevelT
   | TestOptionalHeaderParametersT,
   K
 >;
@@ -923,6 +928,10 @@ export type Client<
 
       readonly testParametersAtPathLevel: TypeofApiCall<
         TestParametersAtPathLevelT
+      >;
+
+      readonly testHeaderParametersAtPathLevel: TypeofApiCall<
+        TestHeaderParametersAtPathLevelT
       >;
 
       readonly testOptionalHeaderParameters: TypeofApiCall<
@@ -1004,6 +1013,13 @@ export type Client<
         ReplaceRequestParams<
           TestParametersAtPathLevelT,
           Omit<RequestParams<TestParametersAtPathLevelT>, K>
+        >
+      >;
+
+      readonly testHeaderParametersAtPathLevel: TypeofApiCall<
+        ReplaceRequestParams<
+          TestHeaderParametersAtPathLevelT,
+          Omit<RequestParams<TestHeaderParametersAtPathLevelT>, K>
         >
       >;
 
@@ -1302,6 +1318,29 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testHeaderParametersAtPathLevelT: ReplaceRequestParams<
+    TestHeaderParametersAtPathLevelT,
+    RequestParams<TestHeaderParametersAtPathLevelT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({
+      [\\"x-header-param\\"]: xHeaderParam
+    }: {
+      \\"x-header-param\\": string;
+    }) => ({
+      \\"x-header-param\\": xHeaderParam
+    }),
+    response_decoder: testHeaderParametersAtPathLevelDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-header-path-level-parameter\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testHeaderParametersAtPathLevel: TypeofApiCall<TestHeaderParametersAtPathLevelT> = createFetchRequestForApi(
+    testHeaderParametersAtPathLevelT,
+    options
+  );
+
   const testOptionalHeaderParametersT: ReplaceRequestParams<
     TestOptionalHeaderParametersT,
     RequestParams<TestOptionalHeaderParametersT>
@@ -1313,7 +1352,7 @@ export function createClient<K extends ParamKeys>({
     }: {
       \\"x-header-param\\"?: string;
     }) => ({
-      \\"x-header-param\\": xHeaderParam_
+      \\"x-header-param\\": xHeaderParam
     }),
     response_decoder: testOptionalHeaderParametersDefaultDecoder(),
     url: ({}) => \`\${basePath}/test-optional-header\`,
@@ -1342,6 +1381,9 @@ export function createClient<K extends ParamKeys>({
     testWithTwoParams: (withDefaults || identity)(testWithTwoParams),
     testParametersAtPathLevel: (withDefaults || identity)(
       testParametersAtPathLevel
+    ),
+    testHeaderParametersAtPathLevel: (withDefaults || identity)(
+      testHeaderParametersAtPathLevel
     ),
     testOptionalHeaderParameters: (withDefaults || identity)(
       testOptionalHeaderParameters

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -815,7 +815,9 @@ import {
   TestWithTwoParamsT,
   testWithTwoParamsDefaultDecoder,
   TestParametersAtPathLevelT,
-  testParametersAtPathLevelDefaultDecoder
+  testParametersAtPathLevelDefaultDecoder,
+  TestOptionalHeaderParametersT,
+  testOptionalHeaderParametersDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -834,7 +836,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestParameterWithDashT> &
   TypeofApiCall<TestParameterWithDashAnUnderscoreT> &
   TypeofApiCall<TestWithTwoParamsT> &
-  TypeofApiCall<TestParametersAtPathLevelT>;
+  TypeofApiCall<TestParametersAtPathLevelT> &
+  TypeofApiCall<TestOptionalHeaderParametersT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimpleTokenT> &
@@ -846,7 +849,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestParameterWithDashT> &
   TypeofApiParams<TestParameterWithDashAnUnderscoreT> &
   TypeofApiParams<TestWithTwoParamsT> &
-  TypeofApiParams<TestParametersAtPathLevelT>);
+  TypeofApiParams<TestParametersAtPathLevelT> &
+  TypeofApiParams<TestOptionalHeaderParametersT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -880,7 +884,8 @@ export type WithDefaultsT<
   | TestParameterWithDashT
   | TestParameterWithDashAnUnderscoreT
   | TestWithTwoParamsT
-  | TestParametersAtPathLevelT,
+  | TestParametersAtPathLevelT
+  | TestOptionalHeaderParametersT,
   K
 >;
 
@@ -918,6 +923,10 @@ export type Client<
 
       readonly testParametersAtPathLevel: TypeofApiCall<
         TestParametersAtPathLevelT
+      >;
+
+      readonly testOptionalHeaderParameters: TypeofApiCall<
+        TestOptionalHeaderParametersT
       >;
     }
   : {
@@ -995,6 +1004,13 @@ export type Client<
         ReplaceRequestParams<
           TestParametersAtPathLevelT,
           Omit<RequestParams<TestParametersAtPathLevelT>, K>
+        >
+      >;
+
+      readonly testOptionalHeaderParameters: TypeofApiCall<
+        ReplaceRequestParams<
+          TestOptionalHeaderParametersT,
+          Omit<RequestParams<TestOptionalHeaderParametersT>, K>
         >
       >;
     };
@@ -1286,6 +1302,29 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testOptionalHeaderParametersT: ReplaceRequestParams<
+    TestOptionalHeaderParametersT,
+    RequestParams<TestOptionalHeaderParametersT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({
+      [\\"x-header-param\\"]: xHeaderParam
+    }: {
+      \\"x-header-param\\"?: string;
+    }) => ({
+      \\"x-header-param\\": xHeaderParam_
+    }),
+    response_decoder: testOptionalHeaderParametersDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-optional-header\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testOptionalHeaderParameters: TypeofApiCall<TestOptionalHeaderParametersT> = createFetchRequestForApi(
+    testOptionalHeaderParametersT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testSimpleToken: (withDefaults || identity)(testSimpleToken),
@@ -1303,6 +1342,9 @@ export function createClient<K extends ParamKeys>({
     testWithTwoParams: (withDefaults || identity)(testWithTwoParams),
     testParametersAtPathLevel: (withDefaults || identity)(
       testParametersAtPathLevel
+    ),
+    testOptionalHeaderParameters: (withDefaults || identity)(
+      testOptionalHeaderParameters
     )
   };
 }

--- a/src/commands/gen-api-models/render.ts
+++ b/src/commands/gen-api-models/render.ts
@@ -19,6 +19,16 @@ import { IDefinition, IOperationInfo, ISpecMetaInfo } from "./types";
 
 const { render } = templateEnvironment;
 
+const standardHeaders: ReadonlyArray<string> = [
+  "Accept-Encoding",
+  "Authorization",
+  "Content-Type",
+  "Host",
+  "If-None-Match",
+  "Ocp-Apim-Subscription-Key",
+  "X-Functions-Key"
+];
+
 /**
  * Render a code block which exports an object literal representing the api specification
  *
@@ -156,8 +166,12 @@ export const renderOperation = (
 
   const requestType = `r.I${capitalize(method)}ApiRequestType`;
 
+  const standardHeadersOnly = headers.filter(h => standardHeaders.includes(h));
+
   const headersCode =
-    headers.length > 0 ? headers.map(_ => `"${_}"`).join("|") : "never";
+    standardHeadersOnly.length > 0
+      ? standardHeadersOnly.map(_ => `"${_}"`).join("|")
+      : "never";
 
   const responsesType = responses
     .map(

--- a/src/commands/gen-api-models/templateEnvironment.ts
+++ b/src/commands/gen-api-models/templateEnvironment.ts
@@ -120,6 +120,24 @@ const stripQuestionMark = (subject: ReadonlyArray<string> | string) => {
 };
 
 /**
+ * Print optional symbol `?` from a variable name
+ * example: "arg?" -> "?"
+ * example: "arg" -> ""
+ * example: ["arg1?", "arg2"] -> ["?", ""]
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const printQuestionMark = (subject: ReadonlyArray<string> | string) => {
+  // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/explicit-function-return-type
+  const getQuestionMark = (str: string) =>
+    str[str.length - 1] === "?" ? "?" : "";
+  return !subject
+    ? undefined
+    : typeof subject === "string"
+    ? getQuestionMark(subject)
+    : subject.map(getQuestionMark);
+};
+
+/**
  * Debug utility for printing a json object within nunjuk templates
  */
 const jsonToString = (obj: unknown): string => JSON.stringify(obj, null, "\t");
@@ -141,6 +159,8 @@ export default createTemplateEnvironment({
     filterByParameterIn,
     filterByParameterNotIn,
     stripQuestionMark,
+    // eslint-disable-next-line sort-keys
+    printQuestionMark,
     // eslint-disable-next-line sort-keys
     jsonToString
   }

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -529,11 +529,11 @@
 {% macro composedHeaderProducers(headerParams, consumes) -%}
   (
     {% if headerParams.length  %}
-    { {% for p in headerParams %}{{p.name | safeDestruct | safe }},{% endfor %} }: 
-    { {% for p in headerParams %}"{{p.name | safe }}":{{p.type}};{% endfor %} }
+    { {% for p in headerParams %}{{p.name | stripQuestionMark | safeDestruct | safe }},{% endfor %} }: 
+    { {% for p in headerParams %}"{{p.name | stripQuestionMark | safe }}"{{p.name | printQuestionMark}}:{{p.type}};{% endfor %} }
     {% endif %}
   ) => ({
-    {% for p in headerParams %}"{{p.headerName}}": {{ tokenize(p) }},{% endfor %}
+    {% for p in headerParams %}"{{p.headerName | stripQuestionMark}}": {{ tokenize(p) }},{% endfor %}
     {% if consumes %}"Content-Type": "{{ consumes }}"{% endif %}
   })
 {% endmacro %}

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -498,7 +498,7 @@
 {% elif headerParam.tokenType === "basic" %}
 `Basic {{ $(headerParam.name | safeIdentifier) }}
 `{% else %}
-{{ headerParam.name | safeIdentifier }}
+{{ headerParam.name | stripQuestionMark | safeIdentifier }}
 {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->


Two different problems have been detected:

1. if an header parameter is optional, its generated name contains _"?"_ at the end of the name, so the generated code does not compile 

2. if an header parameter is defined at path level, generated code does not compile:
Example:

```typescript
// Request type definition
export type TestHeaderParametersAtPathLevelT = r.IGetApiRequestType<
  { readonly "x-header-param": string },
  "x-header-param",
  // ^^^^^^^        ERROR: Type '"x-header-param"' does not satisfy 'RequestHeaderKey'.
  never,
  | r.IResponseType<200, undefined, never>
  | r.IResponseType<500, undefined, never>
>;
```

This because `IGetApiRequestType` from `@pagopa/ts-commons` is defined as 

```typescript
export interface IGetApiRequestType<P, KH extends RequestHeaderKey, Q extends string, R> extends IBaseApiRequestType<"get", P, KH, Q, R> {
    readonly method: "get";
}
```

where `RequestHeaderKey` is 

```typescript
export declare type RequestHeaderKey = "Accept-Encoding" | "Authorization" | "Content-Type" | "Host" | "If-None-Match" | "Ocp-Apim-Subscription-Key" | "X-Functions-Key";
```

So we expect `KH` type to be a subset of `RequestHeaderKey`.

The workaround is, just like what happen for method header parameters, to ignore headers other that the expected ones in request type definition. 


Two failing tests have been added.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR is intended to fix issue #269

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- added unit test and e2e tests that break the current code
- Generated the openapi referenced in issue and built `pagopa-api-config-fe` project corrctly.   
```sh
node dist/commands/gen-api-models/cli --api-spec https://raw.githubusercontent.com/pagopa/pagopa-api-config/main/openapi/swagger.json --no-strict  --out-dir ../pagopa-api-config-fe/generated/api  --request-types --response-decoders --client
```


#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
