### PR TITLE
[IOCIT-60]  [Fix] Responses with no schema

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -218,7 +218,7 @@ paths:
         "200":
           description: "Ok"
         "500":
-          description: "Fatal error"  
+          description: "Fatal error"
   /test-simple:
     patch:
       operationId: "testSimplePatch"
@@ -227,7 +227,7 @@ paths:
         "200":
           description: "Ok"
         "500":
-          description: "Fatal error"                            
+          description: "Fatal error"
   /test-custom-token-header:
     get:
       operationId: "testCustomTokenHeader"
@@ -238,12 +238,19 @@ paths:
         "200":
           description: "Will send `Authenticated`"
         "403":
-          description: "You do not have necessary permissions for the resource"    
+          description: "You do not have necessary permissions for the resource"
+  /test-with-empty-response:
+    get:
+      operationId: "testWithEmptyResponse"
+      responses:
+        "200":
+          $ref: "#/responses/NotFound"
+
 definitions:
   Person:
     $ref: "definitions.yaml#/Person"
   Book:
-    $ref: "definitions.yaml#/Book"        
+    $ref: "definitions.yaml#/Book"
   AllOfTest:
     allOf:
       - type: object
@@ -713,7 +720,10 @@ definitions:
           $ref: "#/definitions/DefinitionFieldWithDash"
     required:
       - items
-responses: {}
+responses:
+  NotFound:
+    description: Not found
+    #content: {} #TODO
 parameters:
   PaginationRequest:
     name: cursor

--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -244,6 +244,13 @@ paths:
           description: "Will send `Authenticated`"
         "403":
           description: "You do not have necessary permissions for the resource"
+  /test-with-empty-response:
+    get:
+      operationId: "testWithEmptyResponse"
+      responses:
+        "200":
+          $ref: "#/components/responses/NotFound"
+          
 # -------------
 # Components
 # -------------
@@ -683,6 +690,13 @@ components:
       schema:
         type: string
   
+  # -------------
+  # Responses
+  # -------------
+  responses:
+    NotFound:
+      description: Not found
+
   # -------------
   # Sec Schemas
   # -------------

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -926,7 +926,9 @@ import {
   TestSimplePatchT,
   testSimplePatchDefaultDecoder,
   TestCustomTokenHeaderT,
-  testCustomTokenHeaderDefaultDecoder
+  testCustomTokenHeaderDefaultDecoder,
+  TestWithEmptyResponseT,
+  testWithEmptyResponseDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -948,7 +950,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestWithTwoParamsT> &
   TypeofApiCall<TestParametersAtPathLevelT> &
   TypeofApiCall<TestSimplePatchT> &
-  TypeofApiCall<TestCustomTokenHeaderT>;
+  TypeofApiCall<TestCustomTokenHeaderT> &
+  TypeofApiCall<TestWithEmptyResponseT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimpleTokenT> &
@@ -963,7 +966,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestWithTwoParamsT> &
   TypeofApiParams<TestParametersAtPathLevelT> &
   TypeofApiParams<TestSimplePatchT> &
-  TypeofApiParams<TestCustomTokenHeaderT>);
+  TypeofApiParams<TestCustomTokenHeaderT> &
+  TypeofApiParams<TestWithEmptyResponseT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -1000,7 +1004,8 @@ export type WithDefaultsT<
   | TestWithTwoParamsT
   | TestParametersAtPathLevelT
   | TestSimplePatchT
-  | TestCustomTokenHeaderT,
+  | TestCustomTokenHeaderT
+  | TestWithEmptyResponseT,
   K
 >;
 
@@ -1047,6 +1052,8 @@ export type Client<
       readonly testSimplePatch: TypeofApiCall<TestSimplePatchT>;
 
       readonly testCustomTokenHeader: TypeofApiCall<TestCustomTokenHeaderT>;
+
+      readonly testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -1144,6 +1151,13 @@ export type Client<
         ReplaceRequestParams<
           TestCustomTokenHeaderT,
           Omit<RequestParams<TestCustomTokenHeaderT>, K>
+        >
+      >;
+
+      readonly testWithEmptyResponse: TypeofApiCall<
+        ReplaceRequestParams<
+          TestWithEmptyResponseT,
+          Omit<RequestParams<TestWithEmptyResponseT>, K>
         >
       >;
     };
@@ -1496,6 +1510,24 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testWithEmptyResponseT: ReplaceRequestParams<
+    TestWithEmptyResponseT,
+    RequestParams<TestWithEmptyResponseT>
+  > = {
+    method: \\"get\\",
+
+    headers: () => ({}),
+
+    response_decoder: testWithEmptyResponseDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-with-empty-response\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT> = createFetchRequestForApi(
+    testWithEmptyResponseT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testSimpleToken: (withDefaults || identity)(testSimpleToken),
@@ -1518,7 +1550,8 @@ export function createClient<K extends ParamKeys>({
       testParametersAtPathLevel
     ),
     testSimplePatch: (withDefaults || identity)(testSimplePatch),
-    testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader)
+    testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
+    testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse)
   };
 }
 "
@@ -2582,7 +2615,9 @@ import {
   TestSimplePatchT,
   testSimplePatchDefaultDecoder,
   TestCustomTokenHeaderT,
-  testCustomTokenHeaderDefaultDecoder
+  testCustomTokenHeaderDefaultDecoder,
+  TestWithEmptyResponseT,
+  testWithEmptyResponseDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -2604,7 +2639,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestWithTwoParamsT> &
   TypeofApiCall<TestParametersAtPathLevelT> &
   TypeofApiCall<TestSimplePatchT> &
-  TypeofApiCall<TestCustomTokenHeaderT>;
+  TypeofApiCall<TestCustomTokenHeaderT> &
+  TypeofApiCall<TestWithEmptyResponseT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimpleTokenT> &
@@ -2619,7 +2655,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestWithTwoParamsT> &
   TypeofApiParams<TestParametersAtPathLevelT> &
   TypeofApiParams<TestSimplePatchT> &
-  TypeofApiParams<TestCustomTokenHeaderT>);
+  TypeofApiParams<TestCustomTokenHeaderT> &
+  TypeofApiParams<TestWithEmptyResponseT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -2656,7 +2693,8 @@ export type WithDefaultsT<
   | TestWithTwoParamsT
   | TestParametersAtPathLevelT
   | TestSimplePatchT
-  | TestCustomTokenHeaderT,
+  | TestCustomTokenHeaderT
+  | TestWithEmptyResponseT,
   K
 >;
 
@@ -2703,6 +2741,8 @@ export type Client<
       readonly testSimplePatch: TypeofApiCall<TestSimplePatchT>;
 
       readonly testCustomTokenHeader: TypeofApiCall<TestCustomTokenHeaderT>;
+
+      readonly testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -2800,6 +2840,13 @@ export type Client<
         ReplaceRequestParams<
           TestCustomTokenHeaderT,
           Omit<RequestParams<TestCustomTokenHeaderT>, K>
+        >
+      >;
+
+      readonly testWithEmptyResponse: TypeofApiCall<
+        ReplaceRequestParams<
+          TestWithEmptyResponseT,
+          Omit<RequestParams<TestWithEmptyResponseT>, K>
         >
       >;
     };
@@ -3162,6 +3209,24 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testWithEmptyResponseT: ReplaceRequestParams<
+    TestWithEmptyResponseT,
+    RequestParams<TestWithEmptyResponseT>
+  > = {
+    method: \\"get\\",
+
+    headers: () => ({}),
+
+    response_decoder: testWithEmptyResponseDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-with-empty-response\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT> = createFetchRequestForApi(
+    testWithEmptyResponseT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testSimpleToken: (withDefaults || identity)(testSimpleToken),
@@ -3184,7 +3249,8 @@ export function createClient<K extends ParamKeys>({
       testParametersAtPathLevel
     ),
     testSimplePatch: (withDefaults || identity)(testSimplePatch),
-    testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader)
+    testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
+    testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse)
   };
 }
 "

--- a/src/commands/gen-api-models/__tests__/parse.test.ts
+++ b/src/commands/gen-api-models/__tests__/parse.test.ts
@@ -75,8 +75,6 @@ describe.each`
     // @ts-ignore
     const parsed = getParser(spec).parseSpecMeta(spec);
 
-    console.log(parsed);
-
     expect(parsed).toEqual(
       expect.objectContaining({
         basePath: "/api/v1",
@@ -207,8 +205,6 @@ describe.each`
       "undefined",
       "undefined"
     )("get");
-
-    console.log(parsed);
 
     expect(parsed).toEqual(
       expect.objectContaining({

--- a/src/commands/gen-api-models/__tests__/parse.test.ts
+++ b/src/commands/gen-api-models/__tests__/parse.test.ts
@@ -196,6 +196,31 @@ describe.each`
       })
     );
   });
+
+  // We are not currently supporting responses as $ref
+  it("should parse an operation with response with no schema setting type to undefined", () => {
+    const parsed = getParser(spec).parseOperation(
+      //@ts-ignore
+      spec,
+      "/test-with-empty-response",
+      [],
+      "undefined",
+      "undefined"
+    )("get");
+
+    console.log(parsed);
+
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        method: "get",
+        path: "/test-with-empty-response",
+        parameters: [],
+        responses: expect.arrayContaining([
+          { e1: "200", e2: "undefined", e3: [] }
+        ])
+      })
+    );
+  });
 });
 
 describe.each`

--- a/src/commands/gen-api-models/parse.v2.ts
+++ b/src/commands/gen-api-models/parse.v2.ts
@@ -321,11 +321,12 @@ export const parseOperation = (
     // We are reading responseStatus from operation.responses keys, so it will never be null
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const response: OpenAPIV2.Response = operation.responses[responseStatus]!;
-    const typeRef = isRefObject(response)
-      ? response.$ref
-      : response.schema !== undefined && isRefObject(response.schema)
-      ? response.schema.$ref
-      : undefined;
+    const typeRef =
+      "schema" in response &&
+      response.schema !== undefined &&
+      isRefObject(response.schema)
+        ? response.schema.$ref
+        : undefined;
     const responseHeaders = Object.keys(
       !isRefObject(response) ? response.headers || {} : {}
     );

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -390,12 +390,11 @@ export const parseOperation = (
       ? response.content?.[Object.keys(response.content ?? {})[0]]
       : undefined;
 
-    const typeRef = isRefObject(response)
-      ? response.$ref
-      : firstMediaContent?.schema !== undefined &&
-        isRefObject(firstMediaContent.schema)
-      ? firstMediaContent.schema.$ref
-      : undefined;
+    const typeRef =
+      firstMediaContent?.schema !== undefined &&
+      isRefObject(firstMediaContent.schema)
+        ? firstMediaContent.schema.$ref
+        : undefined;
     const responseHeaders = Object.keys(
       !isRefObject(response) ? response.headers || {} : {}
     );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->

V11 is generating a `requestTypes.ts` file that is importing a non existing file, when a response $ref is defined within an operation. 
Since we are not currently supporting responses as ref, this PR is to remove response $ref handling.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Bugfixing, V11 introduced a bug that is breaks the build

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test, e2e tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
