### PR TITLE
Import type if the requestBody use a reference

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -156,7 +156,20 @@ paths:
         - name: body
           in: body
           schema:
-            $ref: "#/definitions/Message"
+            $ref: "#/definitions/NewModel"
+      responses:
+        "201":
+          description: "Created"
+        "500":
+          description: "Fatal error"   
+  /put-test-parameter-with-body-ref:
+    put:
+      operationId: "putTestParameterWithBodyReference"
+      parameters:
+        - name: body
+          in: body
+          schema:
+            $ref: "#/definitions/NewModel"
       responses:
         "201":
           description: "Created"
@@ -664,6 +677,17 @@ definitions:
     required:
       - id
       - content
+  NewModel:
+    title: NewModel
+    type: object
+    properties:
+      id: 
+        type: string
+      name:
+        type: string
+    required:
+      - id
+      - name
   Profile:
     title: Profile
     description: Describes the user's profile.

--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -151,13 +151,25 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Message"
-
+              $ref: "#/components/schemas/NewModel"
       responses:
         201:
           description: "Created"
         500:
           description: "Fatal error"   
+  /put-test-parameter-with-body-ref:
+    put:
+      operationId: "putTestParameterWithBodyReference"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewModel"
+      responses:
+        201:
+          description: "Created"
+        500:
+          description: "Fatal error" 
   /test-parameter-with-dash/{path-param}:
     get:
       operationId: "testParameterWithDash"
@@ -390,6 +402,17 @@ components:
       required:
         - id
         - content
+    NewModel:
+      title: NewModel
+      type: object
+      properties:
+        id: 
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - name
     PaginationResponse:
       type: object
       description: Pagination response parameters.

--- a/e2e/src/__tests__/test-api-v3/client.test.ts
+++ b/e2e/src/__tests__/test-api-v3/client.test.ts
@@ -6,6 +6,7 @@ import { createClient } from "../../generated/testapiV3/client";
 
 // @ts-ignore because leaked-handles doesn't ship type defintions
 import * as leaked from "leaked-handles";
+import { NewModel } from "../../generated/testapiV3/NewModel";
 leaked.set({ debugSockets: true });
 
 // Use same config as
@@ -265,8 +266,9 @@ describeSuite("Http client generated from Test API spec", () => {
     expect(isRight(result)).toBe(true);
   });
 
-it("should handle buffer as response", async () => {
-    const base64File = "iVBORw0KGgoAAAANSUhEUgAAAJQAAAB9CAYAAABEd0qeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAZdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuMjHxIGmVAAAGaklEQVR4Xu3cP4gdVRzF8cVWrAQFLbQIlnYKtmI6LSIKWoiFhSCmkhQrFlrYaSo1kEptRBSEWFhZCQH/IEjARkFsxdLC7sm97In3nT135s31zYz3N6f4FO+3M3cGfl/YuNl4stvtzI5GDs1ayaFZKzk0ayWHZq3k0KyVHJq1kkOzVnJo1koOzVrJoVkrOTRrJYdmreTQrJUcmrWSQ7NWcmjWSg7NWsmhWSs5NGslh1v35wf37/4LPm9L5HDrVCRT8HlbIodbw0F89Phd2a237snwuYav4/P4eZHJ4dZwALVQahzUv+RwK3jxZSQtHJaD2lt4GUcLB7XRoHjRZRTJO4/cmfG8hkPaclhyGB0vGIsHB9VODqPDYrFwduvjtzOHNZ0cRoeFYtHMQbWTw6iwSCyYISSmrh0yFhY+RwxLDqNyUPOTw6hqQamIFL5vTC0kfHZQnXNQ85PDaHiRTMVzCHXWFHgvft+eyWE0Dmo5chjNXEExdbaC9wF+357JYTRYnFpuouJooc5WypgSft+eyWE0WNy5xZ6F8NS1v7N7T3eDyngSdY2C688930H1yUEtRw6j4aC+evOFDCH9/OX1DHPGYQDm6p4E5/J1DqpzDmo5chgVFokFAxb/+x+/ZA88eUeGz3w9q93HQQHeg98vAjmMykHNTw6j4W9Vn155JsOCsfgaXMfnTL0fz+Vz+H17JofR8AId1HzkMBos7o1Lj2VrB4X3wDn8vj2Tw2iwOAc1PzmMBotkP15/PcPCa8qIkt++uJrhxwDqnhKeo94h4fftmRxGo5aYOKjjk8PosEgsmoNhCAffqgBzUPcmHBS/TyRyGJ2Dmo8cbkVrWGMBwZZCAjncCgd1fHIYHf5xwNSgpnJQG+Gg5iOHUSEk/BNzLPqbq5czDuvifXdn333/dYa/9AXMcR2HhHMdVFAOan5yGA1C4qA4LA4Kf/hGMDX8h3Scs6WQQA6jcVDLkcMoOCT8yi0gKFxfCwsQDgcEWw4J5DAKB7U8OezdoSFxUMBhHWrLIYEc9s5BrUcOe1cLCgHhHwnUgmIIpYav3zI57J2DWo8c9o5DAg4Jn/n+05Mru+Tmu69k/GsrDNfhPj5vS+Swdw5qPXLYu1pINR9++2uGIPjHA7WwMOfrcQ7O5feLTA5756DWI4e945BqYWHhf918LkMIgGD4B5gM1/H97934IdtSWHLYOwe1HjnsHQKqhQSn79/IsPhaWCqiEl+P8wDP2UJYctg7B7UeOezdoSGxWlBTcUhlXEnksOSwdw5qPXLYOwR1aFhY9O2gzuYqlkG470wZUclBdcZBrUcOo5gaFNwOS0UzgM+pcVCdclDLk8NoVEzJXEHhf+ODz/wcB9U5FVPioI5PDqPBQoGDYhzU5699ko1+FmeVHFQQvFgHNR85jAYLxEJri4bWoPgc4Oc4qM45qOXIYTQcFODrvHAO6lDl2QnOxXMwd1Cdc1DLkcMoxkKCWlCXT16cpHxGUgsKIoYlh1E4qOXJYRRTg4LWoPgcwHP4PRxUZxzU8uQwCge1PDmMohYUL5p/RxxBqf+SGzL2HP66g+qMg1qeHEbBQWHB+MwhwbGCAn4uOKjOOKjlyWHvOCT4vwUF/P49k8PeOaj1yGHvWoP67KVL2U/Xns1UNEPKZ5VqQeE9+f17Joe9c1DrkcMoeIHAC0ZI+Fbnb3nt5DAKtbzEQc1HDqPB4vCtjMOpBfXgo0/vURGVykhKtaD8La9TWKCDmp8cRoVwGIcEDz3x8h4OjCEcxiExfs+eyWFUKqZExZQ4qOnkMCoVzRAOagyHouJK+Dp+z57JYVQqmiEqmiEcioop4ev4PXsmh1GpaIaoaKaoBVTGlfB79kwOo1LRDFGRTIFgHFRQKhoFP15QkUzBf2jHX/FwYPyePZPDqFQ8ioNqJ4dRIZRaQKDiKF24+OoedU2CkHiOsPj9IpDDqBCMg5qPHEbHAdUWzy48/Pyec1+n0MbO5feKQA6jc1DzkcPoeLFji8fX+ZxD71NfS/i8COQwOl7soWHwOYfep76W8HkRyGF0WPTYwvm62jnq3lJ5RsLnRCKH0fGCVQQJX1c7R91bKs9I+JxI5DA6tfQhtRDKSBJ1r8LnRCKH0aklD0EwfE4ZU6LuVficSOQwOrVkhYPhczBX9w7hcyKRw+jUkpUypoTPwVzdO4TPiWN38g8PspbBu6NEtgAAAABJRU5ErkJggg==";
+  it("should handle buffer as response", async () => {
+    const base64File =
+      "iVBORw0KGgoAAAANSUhEUgAAAJQAAAB9CAYAAABEd0qeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAZdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuMjHxIGmVAAAGaklEQVR4Xu3cP4gdVRzF8cVWrAQFLbQIlnYKtmI6LSIKWoiFhSCmkhQrFlrYaSo1kEptRBSEWFhZCQH/IEjARkFsxdLC7sm97In3nT135s31zYz3N6f4FO+3M3cGfl/YuNl4stvtzI5GDs1ayaFZKzk0ayWHZq3k0KyVHJq1kkOzVnJo1koOzVrJoVkrOTRrJYdmreTQrJUcmrWSQ7NWcmjWSg7NWsmhWSs5NGslh1v35wf37/4LPm9L5HDrVCRT8HlbIodbw0F89Phd2a237snwuYav4/P4eZHJ4dZwALVQahzUv+RwK3jxZSQtHJaD2lt4GUcLB7XRoHjRZRTJO4/cmfG8hkPaclhyGB0vGIsHB9VODqPDYrFwduvjtzOHNZ0cRoeFYtHMQbWTw6iwSCyYISSmrh0yFhY+RwxLDqNyUPOTw6hqQamIFL5vTC0kfHZQnXNQ85PDaHiRTMVzCHXWFHgvft+eyWE0Dmo5chjNXEExdbaC9wF+357JYTRYnFpuouJooc5WypgSft+eyWE0WNy5xZ6F8NS1v7N7T3eDyngSdY2C688930H1yUEtRw6j4aC+evOFDCH9/OX1DHPGYQDm6p4E5/J1DqpzDmo5chgVFokFAxb/+x+/ZA88eUeGz3w9q93HQQHeg98vAjmMykHNTw6j4W9Vn155JsOCsfgaXMfnTL0fz+Vz+H17JofR8AId1HzkMBos7o1Lj2VrB4X3wDn8vj2Tw2iwOAc1PzmMBotkP15/PcPCa8qIkt++uJrhxwDqnhKeo94h4fftmRxGo5aYOKjjk8PosEgsmoNhCAffqgBzUPcmHBS/TyRyGJ2Dmo8cbkVrWGMBwZZCAjncCgd1fHIYHf5xwNSgpnJQG+Gg5iOHUSEk/BNzLPqbq5czDuvifXdn333/dYa/9AXMcR2HhHMdVFAOan5yGA1C4qA4LA4Kf/hGMDX8h3Scs6WQQA6jcVDLkcMoOCT8yi0gKFxfCwsQDgcEWw4J5DAKB7U8OezdoSFxUMBhHWrLIYEc9s5BrUcOe1cLCgHhHwnUgmIIpYav3zI57J2DWo8c9o5DAg4Jn/n+05Mru+Tmu69k/GsrDNfhPj5vS+Swdw5qPXLYu1pINR9++2uGIPjHA7WwMOfrcQ7O5feLTA5756DWI4e945BqYWHhf918LkMIgGD4B5gM1/H97934IdtSWHLYOwe1HjnsHQKqhQSn79/IsPhaWCqiEl+P8wDP2UJYctg7B7UeOezdoSGxWlBTcUhlXEnksOSwdw5qPXLYOwR1aFhY9O2gzuYqlkG470wZUclBdcZBrUcOo5gaFNwOS0UzgM+pcVCdclDLk8NoVEzJXEHhf+ODz/wcB9U5FVPioI5PDqPBQoGDYhzU5699ko1+FmeVHFQQvFgHNR85jAYLxEJri4bWoPgc4Oc4qM45qOXIYTQcFODrvHAO6lDl2QnOxXMwd1Cdc1DLkcMoxkKCWlCXT16cpHxGUgsKIoYlh1E4qOXJYRRTg4LWoPgcwHP4PRxUZxzU8uQwCge1PDmMohYUL5p/RxxBqf+SGzL2HP66g+qMg1qeHEbBQWHB+MwhwbGCAn4uOKjOOKjlyWHvOCT4vwUF/P49k8PeOaj1yGHvWoP67KVL2U/Xns1UNEPKZ5VqQeE9+f17Joe9c1DrkcMoeIHAC0ZI+Fbnb3nt5DAKtbzEQc1HDqPB4vCtjMOpBfXgo0/vURGVykhKtaD8La9TWKCDmp8cRoVwGIcEDz3x8h4OjCEcxiExfs+eyWFUKqZExZQ4qOnkMCoVzRAOagyHouJK+Dp+z57JYVQqmiEqmiEcioop4ev4PXsmh1GpaIaoaKaoBVTGlfB79kwOo1LRDFGRTIFgHFRQKhoFP15QkUzBf2jHX/FwYPyePZPDqFQ8ioNqJ4dRIZRaQKDiKF24+OoedU2CkHiOsPj9IpDDqBCMg5qPHEbHAdUWzy48/Pyec1+n0MbO5feKQA6jc1DzkcPoeLFji8fX+ZxD71NfS/i8COQwOl7soWHwOYfep76W8HkRyGF0WPTYwvm62jnq3lJ5RsLnRCKH0fGCVQQJX1c7R91bKs9I+JxI5DA6tfQhtRDKSBJ1r8LnRCKH0aklD0EwfE4ZU6LuVficSOQwOrVkhYPhczBX9w7hcyKRw+jUkpUypoTPwVzdO4TPiWN38g8PspbBu6NEtgAAAABJRU5ErkJggg==";
     var buffer = Buffer.from(base64File);
 
     const client = createClient({
@@ -285,7 +287,6 @@ it("should handle buffer as response", async () => {
         value: buffer
       })
     );
-
   });
 
   it("should allow any custom header", async () => {
@@ -301,5 +302,43 @@ it("should handle buffer as response", async () => {
       customToken: "anystring"
     });
     expect(isRight(result)).toBe(true);
+  });
+
+  it("should handle model ref model in body", async () => {
+    const client = createClient({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: ""
+    });
+
+    const aData: NewModel = {
+      id: "anId",
+      name: "aName"
+    };
+
+    expect(client.testParameterWithBodyReference).toEqual(expect.any(Function));
+    client.testParameterWithBodyReference({ body: aData });
+    // @ts-expect-error
+    client.testParameterWithBodyReference({ body: "" });
+  });
+
+  it("should handle model ref model in body for put operation", async () => {
+    const client = createClient({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: ""
+    });
+
+    const aData: NewModel = {
+      id: "anId",
+      name: "aName"
+    };
+
+    expect(client.putTestParameterWithBodyReference).toEqual(
+      expect.any(Function)
+    );
+    client.putTestParameterWithBodyReference({ body: aData });
+    // @ts-expect-error
+    client.putTestParameterWithBodyReference({ body: "" });
   });
 });

--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -6,6 +6,7 @@ import { createClient } from "../../generated/testapi/client";
 
 // @ts-ignore because leaked-handles doesn't ship type defintions
 import * as leaked from "leaked-handles";
+import { NewModel } from "../../generated/testapi/NewModel";
 leaked.set({ debugSockets: true });
 
 const { skipClient } = config;
@@ -45,7 +46,6 @@ describeSuite("Http client generated from Test API spec", () => {
 
     expect(isRight(result)).toBe(true);
   });
-
 
   it("should make a call, with default parameters", async () => {
     const client = createClient<"bearerToken">({
@@ -246,8 +246,9 @@ describeSuite("Http client generated from Test API spec", () => {
     }
   });
 
-it("should handle buffer as response", async () => {
-    const base64File = "iVBORw0KGgoAAAANSUhEUgAAAJQAAAB9CAYAAABEd0qeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAZdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuMjHxIGmVAAAGaklEQVR4Xu3cP4gdVRzF8cVWrAQFLbQIlnYKtmI6LSIKWoiFhSCmkhQrFlrYaSo1kEptRBSEWFhZCQH/IEjARkFsxdLC7sm97In3nT135s31zYz3N6f4FO+3M3cGfl/YuNl4stvtzI5GDs1ayaFZKzk0ayWHZq3k0KyVHJq1kkOzVnJo1koOzVrJoVkrOTRrJYdmreTQrJUcmrWSQ7NWcmjWSg7NWsmhWSs5NGslh1v35wf37/4LPm9L5HDrVCRT8HlbIodbw0F89Phd2a237snwuYav4/P4eZHJ4dZwALVQahzUv+RwK3jxZSQtHJaD2lt4GUcLB7XRoHjRZRTJO4/cmfG8hkPaclhyGB0vGIsHB9VODqPDYrFwduvjtzOHNZ0cRoeFYtHMQbWTw6iwSCyYISSmrh0yFhY+RwxLDqNyUPOTw6hqQamIFL5vTC0kfHZQnXNQ85PDaHiRTMVzCHXWFHgvft+eyWE0Dmo5chjNXEExdbaC9wF+357JYTRYnFpuouJooc5WypgSft+eyWE0WNy5xZ6F8NS1v7N7T3eDyngSdY2C688930H1yUEtRw6j4aC+evOFDCH9/OX1DHPGYQDm6p4E5/J1DqpzDmo5chgVFokFAxb/+x+/ZA88eUeGz3w9q93HQQHeg98vAjmMykHNTw6j4W9Vn155JsOCsfgaXMfnTL0fz+Vz+H17JofR8AId1HzkMBos7o1Lj2VrB4X3wDn8vj2Tw2iwOAc1PzmMBotkP15/PcPCa8qIkt++uJrhxwDqnhKeo94h4fftmRxGo5aYOKjjk8PosEgsmoNhCAffqgBzUPcmHBS/TyRyGJ2Dmo8cbkVrWGMBwZZCAjncCgd1fHIYHf5xwNSgpnJQG+Gg5iOHUSEk/BNzLPqbq5czDuvifXdn333/dYa/9AXMcR2HhHMdVFAOan5yGA1C4qA4LA4Kf/hGMDX8h3Scs6WQQA6jcVDLkcMoOCT8yi0gKFxfCwsQDgcEWw4J5DAKB7U8OezdoSFxUMBhHWrLIYEc9s5BrUcOe1cLCgHhHwnUgmIIpYav3zI57J2DWo8c9o5DAg4Jn/n+05Mru+Tmu69k/GsrDNfhPj5vS+Swdw5qPXLYu1pINR9++2uGIPjHA7WwMOfrcQ7O5feLTA5756DWI4e945BqYWHhf918LkMIgGD4B5gM1/H97934IdtSWHLYOwe1HjnsHQKqhQSn79/IsPhaWCqiEl+P8wDP2UJYctg7B7UeOezdoSGxWlBTcUhlXEnksOSwdw5qPXLYOwR1aFhY9O2gzuYqlkG470wZUclBdcZBrUcOo5gaFNwOS0UzgM+pcVCdclDLk8NoVEzJXEHhf+ODz/wcB9U5FVPioI5PDqPBQoGDYhzU5699ko1+FmeVHFQQvFgHNR85jAYLxEJri4bWoPgc4Oc4qM45qOXIYTQcFODrvHAO6lDl2QnOxXMwd1Cdc1DLkcMoxkKCWlCXT16cpHxGUgsKIoYlh1E4qOXJYRRTg4LWoPgcwHP4PRxUZxzU8uQwCge1PDmMohYUL5p/RxxBqf+SGzL2HP66g+qMg1qeHEbBQWHB+MwhwbGCAn4uOKjOOKjlyWHvOCT4vwUF/P49k8PeOaj1yGHvWoP67KVL2U/Xns1UNEPKZ5VqQeE9+f17Joe9c1DrkcMoeIHAC0ZI+Fbnb3nt5DAKtbzEQc1HDqPB4vCtjMOpBfXgo0/vURGVykhKtaD8La9TWKCDmp8cRoVwGIcEDz3x8h4OjCEcxiExfs+eyWFUKqZExZQ4qOnkMCoVzRAOagyHouJK+Dp+z57JYVQqmiEqmiEcioop4ev4PXsmh1GpaIaoaKaoBVTGlfB79kwOo1LRDFGRTIFgHFRQKhoFP15QkUzBf2jHX/FwYPyePZPDqFQ8ioNqJ4dRIZRaQKDiKF24+OoedU2CkHiOsPj9IpDDqBCMg5qPHEbHAdUWzy48/Pyec1+n0MbO5feKQA6jc1DzkcPoeLFji8fX+ZxD71NfS/i8COQwOl7soWHwOYfep76W8HkRyGF0WPTYwvm62jnq3lJ5RsLnRCKH0fGCVQQJX1c7R91bKs9I+JxI5DA6tfQhtRDKSBJ1r8LnRCKH0aklD0EwfE4ZU6LuVficSOQwOrVkhYPhczBX9w7hcyKRw+jUkpUypoTPwVzdO4TPiWN38g8PspbBu6NEtgAAAABJRU5ErkJggg==";
+  it("should handle buffer as response", async () => {
+    const base64File =
+      "iVBORw0KGgoAAAANSUhEUgAAAJQAAAB9CAYAAABEd0qeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAZdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuMjHxIGmVAAAGaklEQVR4Xu3cP4gdVRzF8cVWrAQFLbQIlnYKtmI6LSIKWoiFhSCmkhQrFlrYaSo1kEptRBSEWFhZCQH/IEjARkFsxdLC7sm97In3nT135s31zYz3N6f4FO+3M3cGfl/YuNl4stvtzI5GDs1ayaFZKzk0ayWHZq3k0KyVHJq1kkOzVnJo1koOzVrJoVkrOTRrJYdmreTQrJUcmrWSQ7NWcmjWSg7NWsmhWSs5NGslh1v35wf37/4LPm9L5HDrVCRT8HlbIodbw0F89Phd2a237snwuYav4/P4eZHJ4dZwALVQahzUv+RwK3jxZSQtHJaD2lt4GUcLB7XRoHjRZRTJO4/cmfG8hkPaclhyGB0vGIsHB9VODqPDYrFwduvjtzOHNZ0cRoeFYtHMQbWTw6iwSCyYISSmrh0yFhY+RwxLDqNyUPOTw6hqQamIFL5vTC0kfHZQnXNQ85PDaHiRTMVzCHXWFHgvft+eyWE0Dmo5chjNXEExdbaC9wF+357JYTRYnFpuouJooc5WypgSft+eyWE0WNy5xZ6F8NS1v7N7T3eDyngSdY2C688930H1yUEtRw6j4aC+evOFDCH9/OX1DHPGYQDm6p4E5/J1DqpzDmo5chgVFokFAxb/+x+/ZA88eUeGz3w9q93HQQHeg98vAjmMykHNTw6j4W9Vn155JsOCsfgaXMfnTL0fz+Vz+H17JofR8AId1HzkMBos7o1Lj2VrB4X3wDn8vj2Tw2iwOAc1PzmMBotkP15/PcPCa8qIkt++uJrhxwDqnhKeo94h4fftmRxGo5aYOKjjk8PosEgsmoNhCAffqgBzUPcmHBS/TyRyGJ2Dmo8cbkVrWGMBwZZCAjncCgd1fHIYHf5xwNSgpnJQG+Gg5iOHUSEk/BNzLPqbq5czDuvifXdn333/dYa/9AXMcR2HhHMdVFAOan5yGA1C4qA4LA4Kf/hGMDX8h3Scs6WQQA6jcVDLkcMoOCT8yi0gKFxfCwsQDgcEWw4J5DAKB7U8OezdoSFxUMBhHWrLIYEc9s5BrUcOe1cLCgHhHwnUgmIIpYav3zI57J2DWo8c9o5DAg4Jn/n+05Mru+Tmu69k/GsrDNfhPj5vS+Swdw5qPXLYu1pINR9++2uGIPjHA7WwMOfrcQ7O5feLTA5756DWI4e945BqYWHhf918LkMIgGD4B5gM1/H97934IdtSWHLYOwe1HjnsHQKqhQSn79/IsPhaWCqiEl+P8wDP2UJYctg7B7UeOezdoSGxWlBTcUhlXEnksOSwdw5qPXLYOwR1aFhY9O2gzuYqlkG470wZUclBdcZBrUcOo5gaFNwOS0UzgM+pcVCdclDLk8NoVEzJXEHhf+ODz/wcB9U5FVPioI5PDqPBQoGDYhzU5699ko1+FmeVHFQQvFgHNR85jAYLxEJri4bWoPgc4Oc4qM45qOXIYTQcFODrvHAO6lDl2QnOxXMwd1Cdc1DLkcMoxkKCWlCXT16cpHxGUgsKIoYlh1E4qOXJYRRTg4LWoPgcwHP4PRxUZxzU8uQwCge1PDmMohYUL5p/RxxBqf+SGzL2HP66g+qMg1qeHEbBQWHB+MwhwbGCAn4uOKjOOKjlyWHvOCT4vwUF/P49k8PeOaj1yGHvWoP67KVL2U/Xns1UNEPKZ5VqQeE9+f17Joe9c1DrkcMoeIHAC0ZI+Fbnb3nt5DAKtbzEQc1HDqPB4vCtjMOpBfXgo0/vURGVykhKtaD8La9TWKCDmp8cRoVwGIcEDz3x8h4OjCEcxiExfs+eyWFUKqZExZQ4qOnkMCoVzRAOagyHouJK+Dp+z57JYVQqmiEqmiEcioop4ev4PXsmh1GpaIaoaKaoBVTGlfB79kwOo1LRDFGRTIFgHFRQKhoFP15QkUzBf2jHX/FwYPyePZPDqFQ8ioNqJ4dRIZRaQKDiKF24+OoedU2CkHiOsPj9IpDDqBCMg5qPHEbHAdUWzy48/Pyec1+n0MbO5feKQA6jc1DzkcPoeLFji8fX+ZxD71NfS/i8COQwOl7soWHwOYfep76W8HkRyGF0WPTYwvm62jnq3lJ5RsLnRCKH0fGCVQQJX1c7R91bKs9I+JxI5DA6tfQhtRDKSBJ1r8LnRCKH0aklD0EwfE4ZU6LuVficSOQwOrVkhYPhczBX9w7hcyKRw+jUkpUypoTPwVzdO4TPiWN38g8PspbBu6NEtgAAAABJRU5ErkJggg==";
     var buffer = Buffer.from(base64File);
 
     const client = createClient({
@@ -266,8 +267,7 @@ it("should handle buffer as response", async () => {
         value: buffer
       })
     );
-
-  }); 
+  });
 
   it("should make patch http request", async () => {
     const client = createClient({
@@ -301,5 +301,43 @@ it("should handle buffer as response", async () => {
       customToken: "anystring"
     });
     expect(isRight(result)).toBe(true);
+  });
+
+  it("should handle model ref model in body", async () => {
+    const client = createClient({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: ""
+    });
+
+    const aData: NewModel = {
+      id: "anId",
+      name: "aName"
+    };
+
+    expect(client.testParameterWithBodyReference).toEqual(expect.any(Function));
+    client.testParameterWithBodyReference({ body: aData });
+    // @ts-expect-error
+    client.testParameterWithBodyReference({ body: "" });
+  });
+
+  it("should handle model ref model in body for put operation", async () => {
+    const client = createClient({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: ""
+    });
+
+    const aData: NewModel = {
+      id: "anId",
+      name: "aName"
+    };
+
+    expect(client.putTestParameterWithBodyReference).toEqual(
+      expect.any(Function)
+    );
+    client.putTestParameterWithBodyReference({ body: aData });
+    // @ts-expect-error
+    client.putTestParameterWithBodyReference({ body: "" });
   });
 });

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -917,6 +917,8 @@ import {
   testParameterWithReferenceDefaultDecoder,
   TestParameterWithBodyReferenceT,
   testParameterWithBodyReferenceDefaultDecoder,
+  PutTestParameterWithBodyReferenceT,
+  putTestParameterWithBodyReferenceDefaultDecoder,
   TestParameterWithDashT,
   testParameterWithDashDefaultDecoder,
   TestParameterWithDashAnUnderscoreT,
@@ -948,6 +950,7 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestResponseHeaderT> &
   TypeofApiCall<TestParameterWithReferenceT> &
   TypeofApiCall<TestParameterWithBodyReferenceT> &
+  TypeofApiCall<PutTestParameterWithBodyReferenceT> &
   TypeofApiCall<TestParameterWithDashT> &
   TypeofApiCall<TestParameterWithDashAnUnderscoreT> &
   TypeofApiCall<TestWithTwoParamsT> &
@@ -965,6 +968,7 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestResponseHeaderT> &
   TypeofApiParams<TestParameterWithReferenceT> &
   TypeofApiParams<TestParameterWithBodyReferenceT> &
+  TypeofApiParams<PutTestParameterWithBodyReferenceT> &
   TypeofApiParams<TestParameterWithDashT> &
   TypeofApiParams<TestParameterWithDashAnUnderscoreT> &
   TypeofApiParams<TestWithTwoParamsT> &
@@ -1004,6 +1008,7 @@ export type WithDefaultsT<
   | TestResponseHeaderT
   | TestParameterWithReferenceT
   | TestParameterWithBodyReferenceT
+  | PutTestParameterWithBodyReferenceT
   | TestParameterWithDashT
   | TestParameterWithDashAnUnderscoreT
   | TestWithTwoParamsT
@@ -1042,6 +1047,10 @@ export type Client<
 
       readonly testParameterWithBodyReference: TypeofApiCall<
         TestParameterWithBodyReferenceT
+      >;
+
+      readonly putTestParameterWithBodyReference: TypeofApiCall<
+        PutTestParameterWithBodyReferenceT
       >;
 
       readonly testParameterWithDash: TypeofApiCall<TestParameterWithDashT>;
@@ -1123,6 +1132,13 @@ export type Client<
         ReplaceRequestParams<
           TestParameterWithBodyReferenceT,
           Omit<RequestParams<TestParameterWithBodyReferenceT>, K>
+        >
+      >;
+
+      readonly putTestParameterWithBodyReference: TypeofApiCall<
+        ReplaceRequestParams<
+          PutTestParameterWithBodyReferenceT,
+          Omit<RequestParams<PutTestParameterWithBodyReferenceT>, K>
         >
       >;
 
@@ -1406,6 +1422,27 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const putTestParameterWithBodyReferenceT: ReplaceRequestParams<
+    PutTestParameterWithBodyReferenceT,
+    RequestParams<PutTestParameterWithBodyReferenceT>
+  > = {
+    method: \\"put\\",
+
+    headers: () => ({
+      \\"Content-Type\\": \\"application/json\\"
+    }),
+    response_decoder: putTestParameterWithBodyReferenceDefaultDecoder(),
+    url: ({}) => \`\${basePath}/put-test-parameter-with-body-ref\`,
+
+    body: ({ [\\"body\\"]: body }) => JSON.stringify(body),
+
+    query: () => withoutUndefinedValues({})
+  };
+  const putTestParameterWithBodyReference: TypeofApiCall<PutTestParameterWithBodyReferenceT> = createFetchRequestForApi(
+    putTestParameterWithBodyReferenceT,
+    options
+  );
+
   const testParameterWithDashT: ReplaceRequestParams<
     TestParameterWithDashT,
     RequestParams<TestParameterWithDashT>
@@ -1573,6 +1610,9 @@ export function createClient<K extends ParamKeys>({
     ),
     testParameterWithBodyReference: (withDefaults || identity)(
       testParameterWithBodyReference
+    ),
+    putTestParameterWithBodyReference: (withDefaults || identity)(
+      putTestParameterWithBodyReference
     ),
     testParameterWithDash: (withDefaults || identity)(testParameterWithDash),
     testParameterWithDashAnUnderscore: (withDefaults || identity)(
@@ -2639,6 +2679,8 @@ import {
   testParameterWithReferenceDefaultDecoder,
   TestParameterWithBodyReferenceT,
   testParameterWithBodyReferenceDefaultDecoder,
+  PutTestParameterWithBodyReferenceT,
+  putTestParameterWithBodyReferenceDefaultDecoder,
   TestParameterWithDashT,
   testParameterWithDashDefaultDecoder,
   TestParameterWithDashAnUnderscoreT,
@@ -2670,6 +2712,7 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestResponseHeaderT> &
   TypeofApiCall<TestParameterWithReferenceT> &
   TypeofApiCall<TestParameterWithBodyReferenceT> &
+  TypeofApiCall<PutTestParameterWithBodyReferenceT> &
   TypeofApiCall<TestParameterWithDashT> &
   TypeofApiCall<TestParameterWithDashAnUnderscoreT> &
   TypeofApiCall<TestWithTwoParamsT> &
@@ -2687,6 +2730,7 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestResponseHeaderT> &
   TypeofApiParams<TestParameterWithReferenceT> &
   TypeofApiParams<TestParameterWithBodyReferenceT> &
+  TypeofApiParams<PutTestParameterWithBodyReferenceT> &
   TypeofApiParams<TestParameterWithDashT> &
   TypeofApiParams<TestParameterWithDashAnUnderscoreT> &
   TypeofApiParams<TestWithTwoParamsT> &
@@ -2726,6 +2770,7 @@ export type WithDefaultsT<
   | TestResponseHeaderT
   | TestParameterWithReferenceT
   | TestParameterWithBodyReferenceT
+  | PutTestParameterWithBodyReferenceT
   | TestParameterWithDashT
   | TestParameterWithDashAnUnderscoreT
   | TestWithTwoParamsT
@@ -2764,6 +2809,10 @@ export type Client<
 
       readonly testParameterWithBodyReference: TypeofApiCall<
         TestParameterWithBodyReferenceT
+      >;
+
+      readonly putTestParameterWithBodyReference: TypeofApiCall<
+        PutTestParameterWithBodyReferenceT
       >;
 
       readonly testParameterWithDash: TypeofApiCall<TestParameterWithDashT>;
@@ -2845,6 +2894,13 @@ export type Client<
         ReplaceRequestParams<
           TestParameterWithBodyReferenceT,
           Omit<RequestParams<TestParameterWithBodyReferenceT>, K>
+        >
+      >;
+
+      readonly putTestParameterWithBodyReference: TypeofApiCall<
+        ReplaceRequestParams<
+          PutTestParameterWithBodyReferenceT,
+          Omit<RequestParams<PutTestParameterWithBodyReferenceT>, K>
         >
       >;
 
@@ -3138,6 +3194,27 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const putTestParameterWithBodyReferenceT: ReplaceRequestParams<
+    PutTestParameterWithBodyReferenceT,
+    RequestParams<PutTestParameterWithBodyReferenceT>
+  > = {
+    method: \\"put\\",
+
+    headers: () => ({
+      \\"Content-Type\\": \\"application/json\\"
+    }),
+    response_decoder: putTestParameterWithBodyReferenceDefaultDecoder(),
+    url: ({}) => \`\${basePath}/put-test-parameter-with-body-ref\`,
+
+    body: ({ [\\"body\\"]: body }) => JSON.stringify(body),
+
+    query: () => withoutUndefinedValues({})
+  };
+  const putTestParameterWithBodyReference: TypeofApiCall<PutTestParameterWithBodyReferenceT> = createFetchRequestForApi(
+    putTestParameterWithBodyReferenceT,
+    options
+  );
+
   const testParameterWithDashT: ReplaceRequestParams<
     TestParameterWithDashT,
     RequestParams<TestParameterWithDashT>
@@ -3305,6 +3382,9 @@ export function createClient<K extends ParamKeys>({
     ),
     testParameterWithBodyReference: (withDefaults || identity)(
       testParameterWithBodyReference
+    ),
+    putTestParameterWithBodyReference: (withDefaults || identity)(
+      putTestParameterWithBodyReference
     ),
     testParameterWithDash: (withDefaults || identity)(testParameterWithDash),
     testParameterWithDashAnUnderscore: (withDefaults || identity)(

--- a/src/commands/gen-api-models/__tests__/parse.test.ts
+++ b/src/commands/gen-api-models/__tests__/parse.test.ts
@@ -132,11 +132,11 @@ describe.each`
 
     expect(parsed).toEqual(
       expect.objectContaining({
-        method: 'get',
-        operationId: 'testBinaryFileDownload',
-        responses: [ { e1: '200', e2: 'Buffer', e3: [] } ],
-        path: '/test-binary-file-download',
-        consumes: undefined,
+        method: "get",
+        operationId: "testBinaryFileDownload",
+        responses: [{ e1: "200", e2: "Buffer", e3: [] }],
+        path: "/test-binary-file-download",
+        consumes: undefined
       })
     );
   });
@@ -180,7 +180,32 @@ describe.each`
           {
             name: "body?",
             in: "body",
-            type: "Message"
+            type: "NewModel"
+          }
+        ])
+      })
+    );
+  });
+
+  it("should parse a put operation with body as ref", () => {
+    const parsed = getParser(spec).parseOperation(
+      //@ts-ignore
+      spec,
+      "/put-test-parameter-with-body-ref",
+      [],
+      "undefined",
+      "undefined"
+    )("put");
+
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        method: "put",
+        path: "/put-test-parameter-with-body-ref",
+        parameters: expect.arrayContaining([
+          {
+            name: "body?",
+            in: "body",
+            type: "NewModel"
           }
         ])
       })

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -367,7 +367,7 @@ export const parseOperation = (
           ]
       : [];
 
-  // If the requestBody is a reference, we need to import the type
+  // If the requestBody uses a reference, we need to import the refernced type
   if (bodySchema && isRefObject(bodySchema)) {
     importedTypes.add(
       bodySchema.$ref

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -268,7 +268,7 @@ export const parseOperation = (
   extraParameters: ReadonlyArray<IParameterInfo | IHeaderParameterInfo>,
   defaultSuccessType: string,
   defaultErrorType: string
-  // eslint-disable-next-line complexity, sonarjs/cognitive-complexity
+  // eslint-disable-next-line complexity, sonarjs/cognitive-complexity, max-lines-per-function
 ) => (operationKey: string): IOperationInfo | undefined => {
   const specParameters = api.components?.parameters;
 

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -367,6 +367,16 @@ export const parseOperation = (
           ]
       : [];
 
+  // If the requestBody is a reference, we need to import the type
+  if (bodySchema && isRefObject(bodySchema)) {
+    importedTypes.add(
+      bodySchema.$ref
+        .split("/")
+        .slice()
+        .pop() ?? ""
+    );
+  }
+
   const parameters = [
     ...extraParameters,
     ...authParams,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
Import the referenced type if the requestBody use a reference

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a requestBody use a reference the referenced type is not imported.
The PR fix the bug importing the referenced type.

<img width="1067" alt="Schermata 2022-10-12 alle 10 12 22" src="https://user-images.githubusercontent.com/15610456/195292775-a763fb68-d578-49bd-9030-b22326ce0fd4.png">

<img width="506" alt="Schermata 2022-10-12 alle 10 13 11" src="https://user-images.githubusercontent.com/15610456/195292804-81b87a73-b8e9-4b13-962a-99fe8d2a7c7c.png">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
