### PR TITLE
Support security definition of type http and bearer scheme

### DIFF
--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -32,6 +32,32 @@ paths:
           description: You do not have necessary permissions for the resource
       security:
       - bearerToken: []
+  /test-auth-bearer-http:
+    get:
+      operationId: testAuthBearerHttp
+      parameters:
+      - name: qo
+        in: query
+        schema:
+          type: string
+      - name: qr
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: cursor
+        in: query
+        description: An opaque identifier that points to the next item in the collection.
+        schema:
+          minimum: 1
+          type: string
+      responses:
+        200:
+          description: Will send `Authenticated`
+        403:
+          description: You do not have necessary permissions for the resource
+      security:
+      - bearerTokenHttp: []
   /test-simple-token:
     get:
       operationId: "testSimpleToken"
@@ -740,6 +766,9 @@ components:
       name: Authorization
       in: header
       x-auth-scheme: bearer
+    bearerTokenHttp:
+      type: http
+      scheme: bearer
     simpleToken:
       type: apiKey
       name: X-Functions-Key

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -2663,6 +2663,8 @@ import { identity } from \\"fp-ts/lib/function\\";
 import {
   TestAuthBearerT,
   testAuthBearerDefaultDecoder,
+  TestAuthBearerHttpT,
+  testAuthBearerHttpDefaultDecoder,
   TestSimpleTokenT,
   testSimpleTokenDefaultDecoder,
   TestMultipleSuccessT,
@@ -2704,6 +2706,7 @@ import {
 type __UNDEFINED_KEY = \\"_____\\";
 
 export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
+  TypeofApiCall<TestAuthBearerHttpT> &
   TypeofApiCall<TestSimpleTokenT> &
   TypeofApiCall<TestMultipleSuccessT> &
   TypeofApiCall<TestFileUploadT> &
@@ -2722,6 +2725,7 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestWithEmptyResponseT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
+  TypeofApiParams<TestAuthBearerHttpT> &
   TypeofApiParams<TestSimpleTokenT> &
   TypeofApiParams<TestMultipleSuccessT> &
   TypeofApiParams<TestFileUploadT> &
@@ -2762,6 +2766,7 @@ export type WithDefaultsT<
   K extends ParamKeys | __UNDEFINED_KEY = __UNDEFINED_KEY
 > = OmitApiCallParams<
   | TestAuthBearerT
+  | TestAuthBearerHttpT
   | TestSimpleTokenT
   | TestMultipleSuccessT
   | TestFileUploadT
@@ -2790,6 +2795,8 @@ export type Client<
 > = K extends __UNDEFINED_KEY
   ? {
       readonly testAuthBearer: TypeofApiCall<TestAuthBearerT>;
+
+      readonly testAuthBearerHttp: TypeofApiCall<TestAuthBearerHttpT>;
 
       readonly testSimpleToken: TypeofApiCall<TestSimpleTokenT>;
 
@@ -2838,6 +2845,13 @@ export type Client<
         ReplaceRequestParams<
           TestAuthBearerT,
           Omit<RequestParams<TestAuthBearerT>, K>
+        >
+      >;
+
+      readonly testAuthBearerHttp: TypeofApiCall<
+        ReplaceRequestParams<
+          TestAuthBearerHttpT,
+          Omit<RequestParams<TestAuthBearerHttpT>, K>
         >
       >;
 
@@ -3012,6 +3026,30 @@ export function createClient<K extends ParamKeys>({
   };
   const testAuthBearer: TypeofApiCall<TestAuthBearerT> = createFetchRequestForApi(
     testAuthBearerT,
+    options
+  );
+
+  const testAuthBearerHttpT: ReplaceRequestParams<
+    TestAuthBearerHttpT,
+    RequestParams<TestAuthBearerHttpT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({
+      [\\"bearerTokenHttp\\"]: bearerTokenHttp
+    }: {
+      bearerTokenHttp: string;
+    }) => ({
+      Authorization: \`Bearer \${bearerTokenHttp}\`
+    }),
+    response_decoder: testAuthBearerHttpDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-auth-bearer-http\`,
+
+    query: ({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor }) =>
+      withoutUndefinedValues({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor })
+  };
+  const testAuthBearerHttp: TypeofApiCall<TestAuthBearerHttpT> = createFetchRequestForApi(
+    testAuthBearerHttpT,
     options
   );
 
@@ -3371,6 +3409,7 @@ export function createClient<K extends ParamKeys>({
 
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
+    testAuthBearerHttp: (withDefaults || identity)(testAuthBearerHttp),
     testSimpleToken: (withDefaults || identity)(testSimpleToken),
     testMultipleSuccess: (withDefaults || identity)(testMultipleSuccess),
     testFileUpload: (withDefaults || identity)(testFileUpload),

--- a/src/commands/gen-api-models/__tests__/parse.test.ts
+++ b/src/commands/gen-api-models/__tests__/parse.test.ts
@@ -12,7 +12,7 @@ describe.each`
   version | specPath
   ${2}    | ${`${process.cwd()}/__mocks__/api.yaml`}
   ${3}    | ${`${process.cwd()}/__mocks__/openapi_v3/api.yaml`}
-`("Openapi V$version |> getAuthHeaders", ({ specPath }) => {
+`("Openapi V$version |> getAuthHeaders", ({ specPath, version }) => {
   beforeAll(async () => {
     spec = (await SwaggerParser.bundle(specPath)) as
       | OpenAPIV2.Document
@@ -43,6 +43,34 @@ describe.each`
         type: "string"
       })
     ]);
+  });
+
+  it("should parse a security definition with bearer token http", () => {
+    // basically, this tell which security defintion we select
+    const security = [
+      {
+        bearerTokenHttp: []
+      }
+    ];
+    const parsed = isOpenAPIV2(spec)
+      ? getParser(spec).getAuthHeaders(spec.securityDefinitions, security)
+      : getParser(spec).getAuthHeaders(
+          spec?.components?.securitySchemes,
+          security
+        );
+
+    if(version === 3) {
+      expect(parsed).toEqual([
+        expect.objectContaining({
+          authScheme: "bearer",
+          headerName: "Authorization",
+          in: "header",
+          name: "bearerTokenHttp",
+          tokenType: "apiKey",
+          type: "string"
+        })
+      ]);
+    }
   });
 
   it("should parse a security definition with no auth schema", () => {

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -613,6 +613,25 @@ const parseParamWithReference = (
   };
 };
 
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+function convertV3HttpSecurityDefToV2ApiKeySecurityDef(
+  securityDef: ITuple2<
+    string,
+    OpenAPIV3.ReferenceObject | OpenAPIV3.SecuritySchemeObject
+  >
+): ITuple2<string, OpenAPIV3.ReferenceObject | OpenAPIV3.SecuritySchemeObject> {
+  const e2 = securityDef.e2;
+  if (!isRefObject(e2) && e2.type === "http" && e2.scheme === "bearer") {
+    return Tuple2(securityDef.e1, {
+      in: "header",
+      name: "Authorization",
+      type: "apiKey",
+      "x-auth-scheme": "bearer"
+    } as OpenAPIV3.SecuritySchemeObject);
+  }
+  return securityDef;
+}
+
 /**
  * Parse security along with security definitions to obtain a collection of tuples in the form (keyName, headerName).
  * It works with security object both global and operation-specific.
@@ -650,6 +669,7 @@ export function getAuthHeaders(
 
   return securityDefs
     .filter(_ => _.e2 !== undefined)
+    .map(convertV3HttpSecurityDefToV2ApiKeySecurityDef)
     .filter(
       _ =>
         // eslint-disable-next-line no-prototype-builtins

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -613,6 +613,12 @@ const parseParamWithReference = (
   };
 };
 
+/**
+ * Convert a security definition of type 'http' (v3 only) to a security definition of type 'apiKey'.
+ *
+ * @param securityDef of any type
+ * @returns securityDef of type 'apiKey'
+ */
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function convertV3HttpSecurityDefToV2ApiKeySecurityDef(
   securityDef: ITuple2<


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
The PR allow to correctly generate header operations parameter from a security schema of type http and scheme bearer
To support security scheme of type http and scheme bearer we convert

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the security schema is defined with type http and scheme bearer like below

```
BearerAuth:
      type: http
      scheme: bearer
```

the generated operations types do not include the header parameter.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have added test on parser output and tried to generate the client from an openapi v3 spec.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
