### PR TITLE
[#IC-515] Bundle SDK package with `no-strict` definitions

### DIFF
--- a/src/commands/gen-api-sdk/cli.ts
+++ b/src/commands/gen-api-sdk/cli.ts
@@ -102,13 +102,6 @@ const argv = yargs
     // eslint-disable-next-line sort-keys
     group: CODE_GROUP
   })
-  .option("strict", {
-    // eslint-disable-next-line id-blacklist
-    boolean: true,
-    default: true,
-    description: "Generate strict interfaces (default: true)",
-    group: CODE_GROUP
-  })
   .option("out-dir", {
     alias: "o",
     demandOption: true,
@@ -167,8 +160,7 @@ generateSdk({
   defaultErrorType: argv["default-error-type"],
   defaultSuccessType: argv["default-success-type"],
   outPath: argv["out-dir"],
-  specFilePath: argv["api-spec"],
-  strictInterfaces: argv.strict
+  specFilePath: argv["api-spec"]
 }).then(
   // eslint-disable-next-line no-console
   () => console.log("done"),

--- a/src/commands/gen-api-sdk/index.ts
+++ b/src/commands/gen-api-sdk/index.ts
@@ -16,19 +16,128 @@ const { render } = createTemplateEnvironment({
   templateDir: `${DEFAULT_TEMPLATE_DIR}/sdk`
 });
 
+const inferAttributesFromPackage = async (): Promise<IPackageAttributes &
+  IRegistryAttributes> => {
+  const pkg = await fs
+    .readFile(`${process.cwd()}/package.json`)
+    .then(String)
+    .then(JSON.parse)
+    .catch(ex => {
+      throw new Error(
+        `Failed to read package.json from the current directory: ${ex}`
+      );
+    });
+  return {
+    access: pkg.publishConfig?.access,
+    author: pkg.author,
+    description: `Generated SDK for ${pkg.name}. ${pkg.description}`,
+    license: pkg.license,
+    name: `${pkg.name}-sdk`,
+    registry: pkg.publishConfig?.registry,
+    version: pkg.version
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
+const mergeParams = <A extends object, B extends object>(a: A, b: B): any =>
+  Object.keys({ ...a, ...b }).reduce(
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    (p: object, k: string) => ({
+      ...p,
+      [k]: b[k as keyof B] || a[k as keyof A]
+    }),
+    {}
+  );
+
+/**
+ * Renders all templates and return a hashmap in the form (filepath, renderedCode)
+ *
+ * @param options
+ */
+export const renderAll = async (
+  files: ReadonlyArray<string>,
+  options: IPackageAttributes & IRegistryAttributes & IGeneratorParams
+): Promise<Record<string, string>> => {
+  const allContent = await Promise.all(
+    files.map(file => render(file, options))
+  );
+  return allContent.reduce(
+    (p: Record<string, string>, rendered: string, i) => ({
+      ...p,
+      [files[i]]: rendered
+    }),
+    {}
+  );
+};
+
+/**
+ * Wraps file writing to expose a common interface and log consistently
+ *
+ * @param name name of the piece of code to render
+ * @param outPath path of the file
+ * @param code code to be saved
+ *
+ */
+const writeGeneratedCodeFile = (
+  name: string,
+  outPath: string,
+  code: string
+): Promise<void> => {
+  // eslint-disable-next-line no-console
+  console.log(`${name} -> ${outPath}`);
+  return fs.writeFile(outPath, code);
+};
+
+const writeAllGeneratedCodeFiles = (
+  outPath: string,
+  files: Record<string, string>
+): Promise<ReadonlyArray<void>> =>
+  Promise.all(
+    Object.keys(files).map((filepath: string) =>
+      writeGeneratedCodeFile(
+        filepath,
+        `${outPath}/${filepath}`.replace(".njk", ""),
+        files[filepath]
+      )
+    )
+  );
+
+const listTemplates = (): ReadonlyArray<string> => [
+  ".npmignore.njk",
+  "package.json.njk",
+  "tsconfig.json.njk",
+  "index.ts.njk"
+];
+
+// generate and save files requires for the package to be published
+const generatePackageFiles = async (
+  options: IGenerateSdkOptions
+): Promise<void> => {
+  const { inferAttr, ...params } = options;
+  const templateParams: IPackageAttributes &
+    IRegistryAttributes &
+    IGeneratorParams = inferAttr
+    ? mergeParams(await inferAttributesFromPackage(), params)
+    : params;
+
+  const renderedFiles = await renderAll(listTemplates(), templateParams);
+
+  await writeAllGeneratedCodeFiles(options.outPath, renderedFiles);
+};
+
 /**
  * Generate models as well as package scaffolding for a sdk that talks to a provided api spec
  *
  * @param options
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, prefer-arrow/prefer-arrow-functions
-export async function generateSdk(options: IGenerateSdkOptions) {
+export const generateSdk = async (
+  options: IGenerateSdkOptions
+): Promise<void> => {
   // ensure target directories to exist
   await fs.ensureDir(options.outPath);
   const outPathNoStrict = `${options.outPath}/no-strict`;
   await fs.ensureDir(outPathNoStrict);
 
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   await generatePackageFiles(options);
 
   // generate definitions both strict and no-strict
@@ -62,124 +171,4 @@ export async function generateSdk(options: IGenerateSdkOptions) {
     specFilePath: options.specFilePath,
     version: options.version
   });
-}
-
-// generate and save files requires for the package to be published
-const generatePackageFiles = async (
-  options: IGenerateSdkOptions
-): Promise<void> => {
-  const { inferAttr, ...params } = options;
-  const templateParams: IPackageAttributes &
-    IRegistryAttributes &
-    IGeneratorParams = inferAttr
-    ? // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      mergeParams(await inferAttributesFromPackage(), params)
-    : params;
-
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  const renderedFiles = await renderAll(listTemplates(), templateParams);
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  await writeAllGeneratedCodeFiles(options.outPath, renderedFiles);
 };
-
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-async function inferAttributesFromPackage(): Promise<
-  IPackageAttributes & IRegistryAttributes
-> {
-  const pkg = await fs
-    .readFile(`${process.cwd()}/package.json`)
-    .then(String)
-    .then(JSON.parse)
-    .catch(ex => {
-      throw new Error(
-        `Failed to read package.json from the current directory: ${ex}`
-      );
-    });
-  return {
-    name: `${pkg.name}-sdk`,
-    version: pkg.version,
-    // eslint-disable-next-line sort-keys
-    description: `Generated SDK for ${pkg.name}. ${pkg.description}`,
-    // eslint-disable-next-line sort-keys
-    author: pkg.author,
-    license: pkg.license,
-    registry: pkg.publishConfig?.registry,
-    // eslint-disable-next-line sort-keys
-    access: pkg.publishConfig?.access
-  };
-}
-
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions, @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
-function mergeParams<A extends object, B extends object>(a: A, b: B): any {
-  return Object.keys({ ...a, ...b }).reduce(
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    (p: object, k: string) => ({
-      ...p,
-      [k]: b[k as keyof B] || a[k as keyof A]
-    }),
-    {}
-  );
-}
-
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-function listTemplates(): ReadonlyArray<string> {
-  return [
-    ".npmignore.njk",
-    "package.json.njk",
-    "tsconfig.json.njk",
-    "index.ts.njk"
-  ];
-}
-
-/**
- * Renders all templates and return a hashmap in the form (filepath, renderedCode)
- *
- * @param options
- */
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export async function renderAll(
-  files: ReadonlyArray<string>,
-  options: IPackageAttributes & IRegistryAttributes & IGeneratorParams
-): Promise<Record<string, string>> {
-  const allContent = await Promise.all(
-    files.map(file => render(file, options))
-  );
-  return allContent.reduce(
-    (p: Record<string, string>, rendered: string, i) => ({
-      ...p,
-      [files[i]]: rendered
-    }),
-    {}
-  );
-}
-
-/**
- * Wraps file writing to expose a common interface and log consistently
- *
- * @param name name of the piece of code to render
- * @param outPath path of the file
- * @param code code to be saved
- *
- */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, prefer-arrow/prefer-arrow-functions
-function writeGeneratedCodeFile(name: string, outPath: string, code: string) {
-  // eslint-disable-next-line no-console
-  console.log(`${name} -> ${outPath}`);
-  return fs.writeFile(outPath, code);
-}
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, prefer-arrow/prefer-arrow-functions
-function writeAllGeneratedCodeFiles(
-  outPath: string,
-  files: Record<string, string>
-) {
-  return Promise.all(
-    Object.keys(files).map((filepath: string) =>
-      writeGeneratedCodeFile(
-        filepath,
-        `${outPath}/${filepath}`.replace(".njk", ""),
-        files[filepath]
-      )
-    )
-  );
-}

--- a/src/commands/gen-api-sdk/types.ts
+++ b/src/commands/gen-api-sdk/types.ts
@@ -8,7 +8,6 @@ export interface IRegistryAttributes {
 export interface IGeneratorParams {
   readonly specFilePath: string | OpenAPIV2.Document;
   readonly outPath: string;
-  readonly strictInterfaces?: boolean;
   readonly defaultSuccessType?: string;
   readonly defaultErrorType?: string;
   readonly camelCasedPropNames: boolean;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about these changes' context. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as if you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
* bundle no-strict definitions into the `no-strict` folder

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Instead of asking the generator to bundle a package either with strict or no-strict definitions, we prefer to have both kinds in the same package. This is because SDKs are usually generated from servers, while clients have to decide which kind of definitions to adopt. 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
