### PR TITLE
Infer `object` type in definitions when possible

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -757,6 +757,15 @@ definitions:
           $ref: "#/definitions/DefinitionFieldWithDash"
     required:
       - items
+  ObjectDefinitionWithImplicitType:
+    # Sometimes type isn't specified, nevertheless we can infer the definition to be an object 
+    # type: object 
+    properties:
+      prop_one:
+        type: string
+      prop_two: 
+        type: string
+
 responses:
   NotFound:
     description: Not found

--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -765,6 +765,13 @@ definitions:
         type: string
       prop_two: 
         type: string
+  ObjectDefinitionWithImplicitTypeAndAdditionalProperties:
+    # Sometimes type isn't specified, nevertheless we can infer the definition to be an object 
+    # type: object 
+    additionalProperties: 
+      type: array
+      items: 
+        type: number
 
 responses:
   NotFound:

--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -727,6 +727,13 @@ components:
           type: string
         prop_two: 
           type: string
+    ObjectDefinitionWithImplicitTypeAndAdditionalProperties:
+      # Sometimes type isn't specified, nevertheless we can infer the definition to be an object 
+      # type: object 
+      additionalProperties: 
+        type: array
+        items: 
+          type: number
 
   # -------------
   # Parameters

--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -719,6 +719,14 @@ components:
           type: boolean
           enum:
             - false
+    ObjectDefinitionWithImplicitType:
+      # Sometimes type isn't specified, nevertheless we can infer the definition to be an object 
+      # type: object 
+      properties:
+        prop_one:
+          type: string
+        prop_two: 
+          type: string
 
   # -------------
   # Parameters

--- a/src/commands/gen-api-models/__tests__/parse.test.ts
+++ b/src/commands/gen-api-models/__tests__/parse.test.ts
@@ -59,7 +59,7 @@ describe.each`
           security
         );
 
-    if(version === 3) {
+    if (version === 3) {
       expect(parsed).toEqual([
         expect.objectContaining({
           authScheme: "bearer",
@@ -377,5 +377,25 @@ describe.each`
     } else {
       fail("a type should be specified");
     }
+  });
+
+  it("should handle ObjectDefinitionWithImplicitType", async () => {
+    const definition = getDefinitionOrFail(
+      spec,
+      "ObjectDefinitionWithImplicitType"
+    );
+
+    const parsed = getParser(spec).parseDefinition(
+      // @ts-ignore
+      definition
+    );
+
+    expect(parsed.type).toBe("object");
+    expect(parsed.properties).toEqual(
+      expect.objectContaining({
+        prop_one: expect.objectContaining({ type: "string" }),
+        prop_two: expect.objectContaining({ type: "string" })
+      })
+    );
   });
 });

--- a/src/commands/gen-api-models/__tests__/parse.test.ts
+++ b/src/commands/gen-api-models/__tests__/parse.test.ts
@@ -398,4 +398,23 @@ describe.each`
       })
     );
   });
+
+  it("should handle ObjectDefinitionWithImplicitTypeAndAdditionalProperties", async () => {
+    const definition = getDefinitionOrFail(
+      spec,
+      "ObjectDefinitionWithImplicitTypeAndAdditionalProperties"
+    );
+
+    const parsed = getParser(spec).parseDefinition(
+      // @ts-ignore
+      definition
+    );
+
+    expect(parsed.type).toBe("object");
+    expect(parsed.additionalProperties).toEqual(
+      expect.objectContaining({
+        type: "array"
+      })
+    );
+  });
 });

--- a/src/commands/gen-api-models/parse.utils.ts
+++ b/src/commands/gen-api-models/parse.utils.ts
@@ -141,9 +141,9 @@ export const inferDefinitionType = (source: IJsonSchema): string => {
   else if (Array.isArray(source.type)) {
     throw invalidTypeError("Array");
   }
-  // If source contains a "property" field, we assume is an object even if "type" is not defined
+  // If source contains a "property" or "additionalProperties" field, we assume is an object even if "type" is not defined
   // This to be allow specification to work even when they are less then perfect
-  else if ("properties" in source) {
+  else if ("properties" in source || "additionalProperties" in source) {
     return "object";
   }
   // For unknown cases, we throw

--- a/src/commands/gen-api-models/parse.utils.ts
+++ b/src/commands/gen-api-models/parse.utils.ts
@@ -125,12 +125,9 @@ export const getParser = <D extends OpenAPI.Document>(
     ? E.of(parserV3)
     : E.left(Error("The specification must be of type OpenAPI 2 or 3"));
 
-export const inferDefinitionType = (source: IJsonSchema): string => {
-  const invalidTypeError = (receivedType: string): Error =>
-    new Error(
-      `Value MUST be a string. Multiple types via an array are not supported. Received: ${receivedType}`
-    );
-
+export const inferDefinitionType = (
+  source: IJsonSchema
+): string | undefined => {
   // We expect type to be a single string
   if (typeof source.type === "string") {
     return source.type;
@@ -139,15 +136,18 @@ export const inferDefinitionType = (source: IJsonSchema): string => {
   // Anyway, this is not permitted by OpenAPI
   // https://swagger.io/specification/#schema-object
   else if (Array.isArray(source.type)) {
-    throw invalidTypeError("Array");
+    new Error(
+      `field type: Value MUST be a string. Multiple types via an array are not supported. Received: Array`
+    );
   }
   // If source contains a "property" or "additionalProperties" field, we assume is an object even if "type" is not defined
   // This to be allow specification to work even when they are less then perfect
   else if ("properties" in source || "additionalProperties" in source) {
     return "object";
   }
-  // For unknown cases, we throw
+  // Some definitions expect an undefined type
+  // For example, allOf, oneOf, etc
   else {
-    throw invalidTypeError("undefined");
+    return source.type;
   }
 };

--- a/src/commands/gen-api-models/parse.utils.ts
+++ b/src/commands/gen-api-models/parse.utils.ts
@@ -1,4 +1,4 @@
-import { OpenAPI, OpenAPIV2, OpenAPIV3 } from "openapi-types";
+import { IJsonSchema, OpenAPI, OpenAPIV2, OpenAPIV3 } from "openapi-types";
 
 import * as E from "fp-ts/Either";
 
@@ -124,3 +124,30 @@ export const getParser = <D extends OpenAPI.Document>(
     : ParseOpenapiV3.isOpenAPIV3(spec)
     ? E.of(parserV3)
     : E.left(Error("The specification must be of type OpenAPI 2 or 3"));
+
+export const inferDefinitionType = (source: IJsonSchema): string => {
+  const invalidTypeError = (receivedType: string): Error =>
+    new Error(
+      `Value MUST be a string. Multiple types via an array are not supported. Received: ${receivedType}`
+    );
+
+  // We expect type to be a single string
+  if (typeof source.type === "string") {
+    return source.type;
+  }
+  // As for JSON Schema, "type" might be an array of string
+  // Anyway, this is not permitted by OpenAPI
+  // https://swagger.io/specification/#schema-object
+  else if (Array.isArray(source.type)) {
+    throw invalidTypeError("Array");
+  }
+  // If source contains a "property" field, we assume is an object even if "type" is not defined
+  // This to be allow specification to work even when they are less then perfect
+  else if ("properties" in source) {
+    return "object";
+  }
+  // For unknown cases, we throw
+  else {
+    throw invalidTypeError("undefined");
+  }
+};

--- a/src/commands/gen-api-models/parse.v2.ts
+++ b/src/commands/gen-api-models/parse.v2.ts
@@ -5,6 +5,7 @@
 import { ITuple2, Tuple2, Tuple3 } from "@pagopa/ts-commons/lib/tuples";
 import { OpenAPIV2, IJsonSchema, OpenAPI } from "openapi-types";
 import { uncapitalize } from "../../lib/utils";
+import { inferDefinitionType } from "./parse.utils";
 import {
   ExtendedOpenAPIV2SecuritySchemeApiKey,
   IAuthHeaderParameterInfo,
@@ -94,7 +95,7 @@ function parseInnerDefinition(source: IJsonSchema): IDefinition {
     pattern: source.pattern,
     required: source.required,
     title: source.title,
-    type: source.type,
+    type: inferDefinitionType(source),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ["x-import"]: (source as any)["x-import"]
   };

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -6,6 +6,7 @@
 import { ITuple2, Tuple2, Tuple3 } from "@pagopa/ts-commons/lib/tuples";
 import { OpenAPI, OpenAPIV3, IJsonSchema } from "openapi-types";
 import { uncapitalize } from "../../lib/utils";
+import { inferDefinitionType } from "./parse.utils";
 import {
   ExtendedOpenAPIV2SecuritySchemeApiKey,
   IAuthHeaderParameterInfo,
@@ -103,7 +104,7 @@ function parseInnerDefinition(source: IJsonSchema): IDefinition {
     pattern: source.pattern?.split("\\").join("\\\\"),
     required: source.required,
     title: source.title,
-    type: source.type,
+    type: inferDefinitionType(source),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ["x-import"]: (source as any)["x-import"]
   };

--- a/src/commands/gen-api-models/types.ts
+++ b/src/commands/gen-api-models/types.ts
@@ -87,7 +87,7 @@ type ReferenceObject = OpenAPIV3.ReferenceObject;
  */
 export interface IDefinition {
   readonly title?: string;
-  readonly type?: string | ReadonlyArray<string>;
+  readonly type?: string;
   readonly description?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly default?: any;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about these changes' context. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as if you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
* Infer `type=object` when the definition has properties
* Infer `type=object` when the definition has additional properties

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes users have specifications non-100% compliant and do not specify `type` on definitions. Example: https://github.com/pagopa/pn-commons/blob/develop/docs/openapi/pn-errors.yaml#L67.
In some cases, we can infer the correct type by looking at the other definition fields.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
