### PR TITLE
Handle parameters with `$ref` in schema

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -271,7 +271,18 @@ paths:
       responses:
         "200":
           $ref: "#/responses/NotFound"
-
+  /test-param-with-schema-ref/{param}:
+    get:
+      operationId: "testParamWithSchemaRef"
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            $ref: "#/definitions/CustomStringFormatTest"
+      responses:
+        "200":
+          description: "Ok"
 definitions:
   Person:
     $ref: "definitions.yaml#/Person"

--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -299,6 +299,18 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/NotFound"
+  /test-param-with-schema-ref/{param}:
+    get:
+      operationId: "testParamWithSchemaRef"
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/CustomStringFormatTest"
+      responses:
+        "200":
+          description: "Ok"
           
 # -------------
 # Components

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -932,7 +932,9 @@ import {
   TestCustomTokenHeaderT,
   testCustomTokenHeaderDefaultDecoder,
   TestWithEmptyResponseT,
-  testWithEmptyResponseDefaultDecoder
+  testWithEmptyResponseDefaultDecoder,
+  TestParamWithSchemaRefT,
+  testParamWithSchemaRefDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -957,7 +959,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestParametersAtPathLevelT> &
   TypeofApiCall<TestSimplePatchT> &
   TypeofApiCall<TestCustomTokenHeaderT> &
-  TypeofApiCall<TestWithEmptyResponseT>;
+  TypeofApiCall<TestWithEmptyResponseT> &
+  TypeofApiCall<TestParamWithSchemaRefT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimpleTokenT> &
@@ -975,7 +978,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestParametersAtPathLevelT> &
   TypeofApiParams<TestSimplePatchT> &
   TypeofApiParams<TestCustomTokenHeaderT> &
-  TypeofApiParams<TestWithEmptyResponseT>);
+  TypeofApiParams<TestWithEmptyResponseT> &
+  TypeofApiParams<TestParamWithSchemaRefT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -1015,7 +1019,8 @@ export type WithDefaultsT<
   | TestParametersAtPathLevelT
   | TestSimplePatchT
   | TestCustomTokenHeaderT
-  | TestWithEmptyResponseT,
+  | TestWithEmptyResponseT
+  | TestParamWithSchemaRefT,
   K
 >;
 
@@ -1070,6 +1075,8 @@ export type Client<
       readonly testCustomTokenHeader: TypeofApiCall<TestCustomTokenHeaderT>;
 
       readonly testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT>;
+
+      readonly testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -1188,6 +1195,13 @@ export type Client<
         ReplaceRequestParams<
           TestWithEmptyResponseT,
           Omit<RequestParams<TestWithEmptyResponseT>, K>
+        >
+      >;
+
+      readonly testParamWithSchemaRef: TypeofApiCall<
+        ReplaceRequestParams<
+          TestParamWithSchemaRefT,
+          Omit<RequestParams<TestParamWithSchemaRefT>, K>
         >
       >;
     };
@@ -1597,6 +1611,25 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testParamWithSchemaRefT: ReplaceRequestParams<
+    TestParamWithSchemaRefT,
+    RequestParams<TestParamWithSchemaRefT>
+  > = {
+    method: \\"get\\",
+
+    headers: () => ({}),
+
+    response_decoder: testParamWithSchemaRefDefaultDecoder(),
+    url: ({ [\\"param\\"]: param }) =>
+      \`\${basePath}/test-param-with-schema-ref/\${param}\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT> = createFetchRequestForApi(
+    testParamWithSchemaRefT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testSimpleToken: (withDefaults || identity)(testSimpleToken),
@@ -1624,7 +1657,8 @@ export function createClient<K extends ParamKeys>({
     ),
     testSimplePatch: (withDefaults || identity)(testSimplePatch),
     testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
-    testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse)
+    testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse),
+    testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef)
   };
 }
 "
@@ -2696,7 +2730,9 @@ import {
   TestCustomTokenHeaderT,
   testCustomTokenHeaderDefaultDecoder,
   TestWithEmptyResponseT,
-  testWithEmptyResponseDefaultDecoder
+  testWithEmptyResponseDefaultDecoder,
+  TestParamWithSchemaRefT,
+  testParamWithSchemaRefDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -2722,7 +2758,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestParametersAtPathLevelT> &
   TypeofApiCall<TestSimplePatchT> &
   TypeofApiCall<TestCustomTokenHeaderT> &
-  TypeofApiCall<TestWithEmptyResponseT>;
+  TypeofApiCall<TestWithEmptyResponseT> &
+  TypeofApiCall<TestParamWithSchemaRefT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestAuthBearerHttpT> &
@@ -2741,7 +2778,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestParametersAtPathLevelT> &
   TypeofApiParams<TestSimplePatchT> &
   TypeofApiParams<TestCustomTokenHeaderT> &
-  TypeofApiParams<TestWithEmptyResponseT>);
+  TypeofApiParams<TestWithEmptyResponseT> &
+  TypeofApiParams<TestParamWithSchemaRefT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -2782,7 +2820,8 @@ export type WithDefaultsT<
   | TestParametersAtPathLevelT
   | TestSimplePatchT
   | TestCustomTokenHeaderT
-  | TestWithEmptyResponseT,
+  | TestWithEmptyResponseT
+  | TestParamWithSchemaRefT,
   K
 >;
 
@@ -2839,6 +2878,8 @@ export type Client<
       readonly testCustomTokenHeader: TypeofApiCall<TestCustomTokenHeaderT>;
 
       readonly testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT>;
+
+      readonly testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -2964,6 +3005,13 @@ export type Client<
         ReplaceRequestParams<
           TestWithEmptyResponseT,
           Omit<RequestParams<TestWithEmptyResponseT>, K>
+        >
+      >;
+
+      readonly testParamWithSchemaRef: TypeofApiCall<
+        ReplaceRequestParams<
+          TestParamWithSchemaRefT,
+          Omit<RequestParams<TestParamWithSchemaRefT>, K>
         >
       >;
     };
@@ -3407,6 +3455,25 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testParamWithSchemaRefT: ReplaceRequestParams<
+    TestParamWithSchemaRefT,
+    RequestParams<TestParamWithSchemaRefT>
+  > = {
+    method: \\"get\\",
+
+    headers: () => ({}),
+
+    response_decoder: testParamWithSchemaRefDefaultDecoder(),
+    url: ({ [\\"param\\"]: param }) =>
+      \`\${basePath}/test-param-with-schema-ref/\${param}\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT> = createFetchRequestForApi(
+    testParamWithSchemaRefT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testAuthBearerHttp: (withDefaults || identity)(testAuthBearerHttp),
@@ -3435,7 +3502,8 @@ export function createClient<K extends ParamKeys>({
     ),
     testSimplePatch: (withDefaults || identity)(testSimplePatch),
     testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
-    testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse)
+    testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse),
+    testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef)
   };
 }
 "

--- a/src/commands/gen-api-models/__tests__/parse.test.ts
+++ b/src/commands/gen-api-models/__tests__/parse.test.ts
@@ -291,6 +291,34 @@ describe.each`
       })
     );
   });
+
+  it("should dfsejdfvdfsadvfsda", () => {
+    const parsed = getParser(spec).parseOperation(
+      //@ts-ignore
+      spec,
+      "/test-param-with-schema-ref/{param}",
+      [],
+      "undefined",
+      "undefined"
+    )("get");
+
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        method: "get",
+        path: "/test-param-with-schema-ref/{param}",
+        parameters: [
+          expect.objectContaining({
+            name: "param",
+            in: "path",
+            type: "CustomStringFormatTest"
+          })
+        ],
+        responses: expect.arrayContaining([
+          { e1: "200", e2: "undefined", e3: [] }
+        ])
+      })
+    );
+  });
 });
 
 describe.each`

--- a/src/commands/gen-api-models/parse.v3.ts
+++ b/src/commands/gen-api-models/parse.v3.ts
@@ -518,9 +518,14 @@ const parseParameter = (
 ) => (
   param: OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject
 ): IParameterInfo | undefined =>
-  !isRefObject(param)
-    ? parseInlineParam(param)
-    : parseParamWithReference(specParameters, operationId, param);
+  // is referenced from parameters section
+  isRefObject(param) ||
+  // OR is defined inline but references a component
+  (param.schema && isRefObject(param.schema))
+    ? // then parse parameter using its reference
+      parseParamWithReference(specParameters, operationId, param)
+    : // otherwise compose the parameter based on inline definition
+      parseInlineParam(param);
 
 const parseInlineParam = (
   param: OpenAPIV3.ParameterObject


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
see commit list

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Parameters in this shape
```YAML
parameters:
  - name: param
    in: path
    required: true
    schema:
      $ref: "#/components/schemas/CustomDefinition"
```
are now allowed for OpenAPI V3


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
