### PR TITLE
Remove useless header type in client headers

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -283,6 +283,18 @@ paths:
       responses:
         "200":
           description: "Ok"
+  /test-header-with-schema-ref:
+    get:
+      operationId: "testHeaderWithSchemaRef"
+      parameters:
+        - name: param
+          in: header
+          required: true
+          schema:
+            $ref: "#/definitions/CustomStringFormatTest"
+      responses:
+        "200":
+          description: "Ok"
 definitions:
   Person:
     $ref: "definitions.yaml#/Person"

--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -311,6 +311,18 @@ paths:
       responses:
         "200":
           description: "Ok"
+  /test-header-with-schema-ref:
+    get:
+      operationId: "testHeaderWithSchemaRef"
+      parameters:
+        - name: param
+          in: header
+          required: true
+          schema:
+            $ref: "#/components/schemas/CustomStringFormatTest"
+      responses:
+        "200":
+          description: "Ok"
           
 # -------------
 # Components

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -934,7 +934,9 @@ import {
   TestWithEmptyResponseT,
   testWithEmptyResponseDefaultDecoder,
   TestParamWithSchemaRefT,
-  testParamWithSchemaRefDefaultDecoder
+  testParamWithSchemaRefDefaultDecoder,
+  TestHeaderWithSchemaRefT,
+  testHeaderWithSchemaRefDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -960,7 +962,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestSimplePatchT> &
   TypeofApiCall<TestCustomTokenHeaderT> &
   TypeofApiCall<TestWithEmptyResponseT> &
-  TypeofApiCall<TestParamWithSchemaRefT>;
+  TypeofApiCall<TestParamWithSchemaRefT> &
+  TypeofApiCall<TestHeaderWithSchemaRefT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimpleTokenT> &
@@ -979,7 +982,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimplePatchT> &
   TypeofApiParams<TestCustomTokenHeaderT> &
   TypeofApiParams<TestWithEmptyResponseT> &
-  TypeofApiParams<TestParamWithSchemaRefT>);
+  TypeofApiParams<TestParamWithSchemaRefT> &
+  TypeofApiParams<TestHeaderWithSchemaRefT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -1020,7 +1024,8 @@ export type WithDefaultsT<
   | TestSimplePatchT
   | TestCustomTokenHeaderT
   | TestWithEmptyResponseT
-  | TestParamWithSchemaRefT,
+  | TestParamWithSchemaRefT
+  | TestHeaderWithSchemaRefT,
   K
 >;
 
@@ -1077,6 +1082,8 @@ export type Client<
       readonly testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT>;
 
       readonly testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT>;
+
+      readonly testHeaderWithSchemaRef: TypeofApiCall<TestHeaderWithSchemaRefT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -1204,6 +1211,13 @@ export type Client<
           Omit<RequestParams<TestParamWithSchemaRefT>, K>
         >
       >;
+
+      readonly testHeaderWithSchemaRef: TypeofApiCall<
+        ReplaceRequestParams<
+          TestHeaderWithSchemaRefT,
+          Omit<RequestParams<TestHeaderWithSchemaRefT>, K>
+        >
+      >;
     };
 
 /**
@@ -1253,7 +1267,7 @@ export function createClient<K extends ParamKeys>({
   > = {
     method: \\"get\\",
 
-    headers: ({ [\\"bearerToken\\"]: bearerToken }: { bearerToken: string }) => ({
+    headers: ({ [\\"bearerToken\\"]: bearerToken }) => ({
       Authorization: \`Bearer \${bearerToken}\`
     }),
     response_decoder: testAuthBearerDefaultDecoder(),
@@ -1273,7 +1287,7 @@ export function createClient<K extends ParamKeys>({
   > = {
     method: \\"get\\",
 
-    headers: ({ [\\"simpleToken\\"]: simpleToken }: { simpleToken: string }) => ({
+    headers: ({ [\\"simpleToken\\"]: simpleToken }) => ({
       \\"X-Functions-Key\\": simpleToken
     }),
     response_decoder: testSimpleTokenDefaultDecoder(),
@@ -1466,9 +1480,6 @@ export function createClient<K extends ParamKeys>({
     headers: ({
       [\\"headerInlineParam\\"]: headerInlineParam,
       [\\"x-header-param\\"]: xHeaderParam
-    }: {
-      headerInlineParam: string;
-      \\"x-header-param\\": string;
     }) => ({
       headerInlineParam: headerInlineParam,
 
@@ -1495,9 +1506,6 @@ export function createClient<K extends ParamKeys>({
     headers: ({
       [\\"headerInlineParam\\"]: headerInlineParam,
       [\\"x-header-param\\"]: xHeaderParam
-    }: {
-      headerInlineParam: string;
-      \\"x-header-param\\": string;
     }) => ({
       headerInlineParam: headerInlineParam,
 
@@ -1580,7 +1588,7 @@ export function createClient<K extends ParamKeys>({
   > = {
     method: \\"get\\",
 
-    headers: ({ [\\"customToken\\"]: customToken }: { customToken: string }) => ({
+    headers: ({ [\\"customToken\\"]: customToken }) => ({
       \\"custom-token\\": customToken
     }),
     response_decoder: testCustomTokenHeaderDefaultDecoder(),
@@ -1630,6 +1638,25 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testHeaderWithSchemaRefT: ReplaceRequestParams<
+    TestHeaderWithSchemaRefT,
+    RequestParams<TestHeaderWithSchemaRefT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({ [\\"param\\"]: param }) => ({
+      param: param
+    }),
+    response_decoder: testHeaderWithSchemaRefDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-header-with-schema-ref\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testHeaderWithSchemaRef: TypeofApiCall<TestHeaderWithSchemaRefT> = createFetchRequestForApi(
+    testHeaderWithSchemaRefT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testSimpleToken: (withDefaults || identity)(testSimpleToken),
@@ -1658,7 +1685,8 @@ export function createClient<K extends ParamKeys>({
     testSimplePatch: (withDefaults || identity)(testSimplePatch),
     testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
     testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse),
-    testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef)
+    testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef),
+    testHeaderWithSchemaRef: (withDefaults || identity)(testHeaderWithSchemaRef)
   };
 }
 "
@@ -2732,7 +2760,9 @@ import {
   TestWithEmptyResponseT,
   testWithEmptyResponseDefaultDecoder,
   TestParamWithSchemaRefT,
-  testParamWithSchemaRefDefaultDecoder
+  testParamWithSchemaRefDefaultDecoder,
+  TestHeaderWithSchemaRefT,
+  testHeaderWithSchemaRefDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -2759,7 +2789,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestSimplePatchT> &
   TypeofApiCall<TestCustomTokenHeaderT> &
   TypeofApiCall<TestWithEmptyResponseT> &
-  TypeofApiCall<TestParamWithSchemaRefT>;
+  TypeofApiCall<TestParamWithSchemaRefT> &
+  TypeofApiCall<TestHeaderWithSchemaRefT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestAuthBearerHttpT> &
@@ -2779,7 +2810,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimplePatchT> &
   TypeofApiParams<TestCustomTokenHeaderT> &
   TypeofApiParams<TestWithEmptyResponseT> &
-  TypeofApiParams<TestParamWithSchemaRefT>);
+  TypeofApiParams<TestParamWithSchemaRefT> &
+  TypeofApiParams<TestHeaderWithSchemaRefT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -2821,7 +2853,8 @@ export type WithDefaultsT<
   | TestSimplePatchT
   | TestCustomTokenHeaderT
   | TestWithEmptyResponseT
-  | TestParamWithSchemaRefT,
+  | TestParamWithSchemaRefT
+  | TestHeaderWithSchemaRefT,
   K
 >;
 
@@ -2880,6 +2913,8 @@ export type Client<
       readonly testWithEmptyResponse: TypeofApiCall<TestWithEmptyResponseT>;
 
       readonly testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT>;
+
+      readonly testHeaderWithSchemaRef: TypeofApiCall<TestHeaderWithSchemaRefT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -3014,6 +3049,13 @@ export type Client<
           Omit<RequestParams<TestParamWithSchemaRefT>, K>
         >
       >;
+
+      readonly testHeaderWithSchemaRef: TypeofApiCall<
+        ReplaceRequestParams<
+          TestHeaderWithSchemaRefT,
+          Omit<RequestParams<TestHeaderWithSchemaRefT>, K>
+        >
+      >;
     };
 
 /**
@@ -3063,7 +3105,7 @@ export function createClient<K extends ParamKeys>({
   > = {
     method: \\"get\\",
 
-    headers: ({ [\\"bearerToken\\"]: bearerToken }: { bearerToken: string }) => ({
+    headers: ({ [\\"bearerToken\\"]: bearerToken }) => ({
       Authorization: \`Bearer \${bearerToken}\`
     }),
     response_decoder: testAuthBearerDefaultDecoder(),
@@ -3083,11 +3125,7 @@ export function createClient<K extends ParamKeys>({
   > = {
     method: \\"get\\",
 
-    headers: ({
-      [\\"bearerTokenHttp\\"]: bearerTokenHttp
-    }: {
-      bearerTokenHttp: string;
-    }) => ({
+    headers: ({ [\\"bearerTokenHttp\\"]: bearerTokenHttp }) => ({
       Authorization: \`Bearer \${bearerTokenHttp}\`
     }),
     response_decoder: testAuthBearerHttpDefaultDecoder(),
@@ -3107,7 +3145,7 @@ export function createClient<K extends ParamKeys>({
   > = {
     method: \\"get\\",
 
-    headers: ({ [\\"simpleToken\\"]: simpleToken }: { simpleToken: string }) => ({
+    headers: ({ [\\"simpleToken\\"]: simpleToken }) => ({
       \\"X-Functions-Key\\": simpleToken
     }),
     response_decoder: testSimpleTokenDefaultDecoder(),
@@ -3310,9 +3348,6 @@ export function createClient<K extends ParamKeys>({
     headers: ({
       [\\"headerInlineParam\\"]: headerInlineParam,
       [\\"x-header-param\\"]: xHeaderParam
-    }: {
-      headerInlineParam: string;
-      \\"x-header-param\\": string;
     }) => ({
       headerInlineParam: headerInlineParam,
 
@@ -3339,9 +3374,6 @@ export function createClient<K extends ParamKeys>({
     headers: ({
       [\\"headerInlineParam\\"]: headerInlineParam,
       [\\"x-header-param\\"]: xHeaderParam
-    }: {
-      headerInlineParam: string;
-      \\"x-header-param\\": string;
     }) => ({
       headerInlineParam: headerInlineParam,
 
@@ -3424,7 +3456,7 @@ export function createClient<K extends ParamKeys>({
   > = {
     method: \\"get\\",
 
-    headers: ({ [\\"customToken\\"]: customToken }: { customToken: string }) => ({
+    headers: ({ [\\"customToken\\"]: customToken }) => ({
       \\"custom-token\\": customToken
     }),
     response_decoder: testCustomTokenHeaderDefaultDecoder(),
@@ -3474,6 +3506,25 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testHeaderWithSchemaRefT: ReplaceRequestParams<
+    TestHeaderWithSchemaRefT,
+    RequestParams<TestHeaderWithSchemaRefT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({ [\\"param\\"]: param }) => ({
+      param: param
+    }),
+    response_decoder: testHeaderWithSchemaRefDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-header-with-schema-ref\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testHeaderWithSchemaRef: TypeofApiCall<TestHeaderWithSchemaRefT> = createFetchRequestForApi(
+    testHeaderWithSchemaRefT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testAuthBearerHttp: (withDefaults || identity)(testAuthBearerHttp),
@@ -3503,7 +3554,8 @@ export function createClient<K extends ParamKeys>({
     testSimplePatch: (withDefaults || identity)(testSimplePatch),
     testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
     testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse),
-    testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef)
+    testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef),
+    testHeaderWithSchemaRef: (withDefaults || identity)(testHeaderWithSchemaRef)
   };
 }
 "

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -552,8 +552,7 @@
 {% macro composedHeaderProducers(headerParams, consumes) -%}
   (
     {% if headerParams.length  %}
-    { {% for p in headerParams %}{{p.name | safeDestruct | safe }},{% endfor %} }: 
-    { {% for p in headerParams %}"{{p.name | safe }}":{{p.type}};{% endfor %} }
+    { {% for p in headerParams %}{{p.name | safeDestruct | safe }},{% endfor %} }
     {% endif %}
   ) => ({
     {% for p in headerParams %}"{{p.headerName}}": {{ tokenize(p) }},{% endfor %}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
Fix import bug in the generation of a client with headers using parameters with $ref.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use the generated client with api specs using $ref in typed headers.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
e2e test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
