### PR TITLE
fix: remove `?` from optional header name

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -295,6 +295,19 @@ paths:
       responses:
         "200":
           description: "Ok"
+  /test-header-optional:
+    get:
+      operationId: "testHeaderOptional"
+      parameters:
+        - name: param
+          in: header
+          required: false
+          schema:
+            $ref: "#/definitions/CustomStringFormatTest"
+      responses:
+        "200":
+          description: "Ok"
+
 definitions:
   Person:
     $ref: "definitions.yaml#/Person"

--- a/__mocks__/openapi_v3/api.yaml
+++ b/__mocks__/openapi_v3/api.yaml
@@ -323,6 +323,18 @@ paths:
       responses:
         "200":
           description: "Ok"
+  /test-header-optional:
+    get:
+      operationId: "testHeaderOptional"
+      parameters:
+        - name: param
+          in: header
+          required: false
+          schema:
+            $ref: "#/components/schemas/CustomStringFormatTest"
+      responses:
+        "200":
+          description: "Ok"
           
 # -------------
 # Components

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -936,7 +936,9 @@ import {
   TestParamWithSchemaRefT,
   testParamWithSchemaRefDefaultDecoder,
   TestHeaderWithSchemaRefT,
-  testHeaderWithSchemaRefDefaultDecoder
+  testHeaderWithSchemaRefDefaultDecoder,
+  TestHeaderOptionalT,
+  testHeaderOptionalDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -963,7 +965,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestCustomTokenHeaderT> &
   TypeofApiCall<TestWithEmptyResponseT> &
   TypeofApiCall<TestParamWithSchemaRefT> &
-  TypeofApiCall<TestHeaderWithSchemaRefT>;
+  TypeofApiCall<TestHeaderWithSchemaRefT> &
+  TypeofApiCall<TestHeaderOptionalT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestSimpleTokenT> &
@@ -983,7 +986,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestCustomTokenHeaderT> &
   TypeofApiParams<TestWithEmptyResponseT> &
   TypeofApiParams<TestParamWithSchemaRefT> &
-  TypeofApiParams<TestHeaderWithSchemaRefT>);
+  TypeofApiParams<TestHeaderWithSchemaRefT> &
+  TypeofApiParams<TestHeaderOptionalT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -1025,7 +1029,8 @@ export type WithDefaultsT<
   | TestCustomTokenHeaderT
   | TestWithEmptyResponseT
   | TestParamWithSchemaRefT
-  | TestHeaderWithSchemaRefT,
+  | TestHeaderWithSchemaRefT
+  | TestHeaderOptionalT,
   K
 >;
 
@@ -1084,6 +1089,8 @@ export type Client<
       readonly testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT>;
 
       readonly testHeaderWithSchemaRef: TypeofApiCall<TestHeaderWithSchemaRefT>;
+
+      readonly testHeaderOptional: TypeofApiCall<TestHeaderOptionalT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -1216,6 +1223,13 @@ export type Client<
         ReplaceRequestParams<
           TestHeaderWithSchemaRefT,
           Omit<RequestParams<TestHeaderWithSchemaRefT>, K>
+        >
+      >;
+
+      readonly testHeaderOptional: TypeofApiCall<
+        ReplaceRequestParams<
+          TestHeaderOptionalT,
+          Omit<RequestParams<TestHeaderOptionalT>, K>
         >
       >;
     };
@@ -1669,6 +1683,25 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testHeaderOptionalT: ReplaceRequestParams<
+    TestHeaderOptionalT,
+    RequestParams<TestHeaderOptionalT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({ [\\"param\\"]: param }) => ({
+      param: param
+    }),
+    response_decoder: testHeaderOptionalDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-header-optional\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testHeaderOptional: TypeofApiCall<TestHeaderOptionalT> = createFetchRequestForApi(
+    testHeaderOptionalT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testSimpleToken: (withDefaults || identity)(testSimpleToken),
@@ -1698,7 +1731,10 @@ export function createClient<K extends ParamKeys>({
     testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
     testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse),
     testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef),
-    testHeaderWithSchemaRef: (withDefaults || identity)(testHeaderWithSchemaRef)
+    testHeaderWithSchemaRef: (withDefaults || identity)(
+      testHeaderWithSchemaRef
+    ),
+    testHeaderOptional: (withDefaults || identity)(testHeaderOptional)
   };
 }
 "
@@ -2774,7 +2810,9 @@ import {
   TestParamWithSchemaRefT,
   testParamWithSchemaRefDefaultDecoder,
   TestHeaderWithSchemaRefT,
-  testHeaderWithSchemaRefDefaultDecoder
+  testHeaderWithSchemaRefDefaultDecoder,
+  TestHeaderOptionalT,
+  testHeaderOptionalDefaultDecoder
 } from \\"./requestTypes\\";
 
 // This is a placeholder for undefined when dealing with object keys
@@ -2802,7 +2840,8 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestCustomTokenHeaderT> &
   TypeofApiCall<TestWithEmptyResponseT> &
   TypeofApiCall<TestParamWithSchemaRefT> &
-  TypeofApiCall<TestHeaderWithSchemaRefT>;
+  TypeofApiCall<TestHeaderWithSchemaRefT> &
+  TypeofApiCall<TestHeaderOptionalT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestAuthBearerHttpT> &
@@ -2823,7 +2862,8 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestCustomTokenHeaderT> &
   TypeofApiParams<TestWithEmptyResponseT> &
   TypeofApiParams<TestParamWithSchemaRefT> &
-  TypeofApiParams<TestHeaderWithSchemaRefT>);
+  TypeofApiParams<TestHeaderWithSchemaRefT> &
+  TypeofApiParams<TestHeaderOptionalT>);
 
 /**
  * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
@@ -2866,7 +2906,8 @@ export type WithDefaultsT<
   | TestCustomTokenHeaderT
   | TestWithEmptyResponseT
   | TestParamWithSchemaRefT
-  | TestHeaderWithSchemaRefT,
+  | TestHeaderWithSchemaRefT
+  | TestHeaderOptionalT,
   K
 >;
 
@@ -2927,6 +2968,8 @@ export type Client<
       readonly testParamWithSchemaRef: TypeofApiCall<TestParamWithSchemaRefT>;
 
       readonly testHeaderWithSchemaRef: TypeofApiCall<TestHeaderWithSchemaRefT>;
+
+      readonly testHeaderOptional: TypeofApiCall<TestHeaderOptionalT>;
     }
   : {
       readonly testAuthBearer: TypeofApiCall<
@@ -3066,6 +3109,13 @@ export type Client<
         ReplaceRequestParams<
           TestHeaderWithSchemaRefT,
           Omit<RequestParams<TestHeaderWithSchemaRefT>, K>
+        >
+      >;
+
+      readonly testHeaderOptional: TypeofApiCall<
+        ReplaceRequestParams<
+          TestHeaderOptionalT,
+          Omit<RequestParams<TestHeaderOptionalT>, K>
         >
       >;
     };
@@ -3549,6 +3599,25 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testHeaderOptionalT: ReplaceRequestParams<
+    TestHeaderOptionalT,
+    RequestParams<TestHeaderOptionalT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({ [\\"param\\"]: param }) => ({
+      param: param
+    }),
+    response_decoder: testHeaderOptionalDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-header-optional\`,
+
+    query: () => withoutUndefinedValues({})
+  };
+  const testHeaderOptional: TypeofApiCall<TestHeaderOptionalT> = createFetchRequestForApi(
+    testHeaderOptionalT,
+    options
+  );
+
   return {
     testAuthBearer: (withDefaults || identity)(testAuthBearer),
     testAuthBearerHttp: (withDefaults || identity)(testAuthBearerHttp),
@@ -3579,7 +3648,10 @@ export function createClient<K extends ParamKeys>({
     testCustomTokenHeader: (withDefaults || identity)(testCustomTokenHeader),
     testWithEmptyResponse: (withDefaults || identity)(testWithEmptyResponse),
     testParamWithSchemaRef: (withDefaults || identity)(testParamWithSchemaRef),
-    testHeaderWithSchemaRef: (withDefaults || identity)(testHeaderWithSchemaRef)
+    testHeaderWithSchemaRef: (withDefaults || identity)(
+      testHeaderWithSchemaRef
+    ),
+    testHeaderOptional: (withDefaults || identity)(testHeaderOptional)
   };
 }
 "

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -515,13 +515,13 @@
  #}
 {% macro tokenize(headerParam) -%}
 {% if headerParam.tokenType === "apiKey" and headerParam.authScheme and headerParam.authScheme !== "none" %}
-`{{ headerParam.authScheme | capitalizeFirst }} {{ $(headerParam.name | safeIdentifier) }}`
+`{{ headerParam.authScheme | capitalizeFirst }} {{ $(headerParam.name | stripQuestionMark | safeIdentifier) }}`
 {% elif headerParam.tokenType === "oauth" %}
-`Bearer {{ $(headerParam.name | safeIdentifier ) }}`
+`Bearer {{ $(headerParam.name | stripQuestionMark | safeIdentifier ) }}`
 {% elif headerParam.tokenType === "basic" %}
-`Basic {{ $(headerParam.name | safeIdentifier) }}
+`Basic {{ $(headerParam.name | stripQuestionMark | safeIdentifier) }}
 `{% else %}
-{{ headerParam.name | safeIdentifier }}
+{{ headerParam.name | stripQuestionMark  | safeIdentifier }}
 {% endif %}
 {% endmacro %}
 
@@ -552,10 +552,10 @@
 {% macro composedHeaderProducers(headerParams, consumes) -%}
   (
     {% if headerParams.length  %}
-    { {% for p in headerParams %}{{p.name | safeDestruct | safe }},{% endfor %} }
+    { {% for p in headerParams %}{{p.name | stripQuestionMark | safeDestruct | safe }},{% endfor %} }
     {% endif %}
   ) => ({
-    {% for p in headerParams %}"{{p.headerName}}": {{ tokenize(p) }},{% endfor %}
+    {% for p in headerParams %}"{{p.headerName  | stripQuestionMark }}": {{ tokenize(p) }},{% endfor %}
     {% if consumes %}"Content-Type": "{{ consumes }}"{% endif %}
   })
 {% endmacro %}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->

- remove `?` from optional header name
- add new openapi v2 and v3 endpoint
- add snaptshots

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

when there is an optional header, the client is built with a question mark at the end of the header name, causing the build to fail

```
  const testHeaderOptionalT: ReplaceRequestParams<
    TestHeaderOptionalT,
    RequestParams<TestHeaderOptionalT>
  > = {
    method: \\"get\\",

    headers: ({ [\\"param?\\"]: param_ }) => ({
      param?: param_
    }),
    response_decoder: testHeaderOptionalDefaultDecoder(),
    url: ({}) => \`\${basePath}/test-header-optional\`,

    query: () => withoutUndefinedValues({})
  };
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
