### PR TITLE
[BUG] compilation fails setting `withDefaults` under certain conditions

### DIFF
--- a/__mocks__/api_test_defaults.yaml
+++ b/__mocks__/api_test_defaults.yaml
@@ -1,0 +1,76 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: WithDefaults Test API
+  description: An Openapi for testing client default parameters
+host: localhost
+basePath: /api/v1
+schemes:
+  - https
+
+securityDefinitions:
+  bearerToken:
+    type: apiKey
+    name: Authorization
+    in: header
+    x-auth-scheme: bearer
+
+security:
+  - Bearer: []
+
+paths:
+  /test-1:
+    get:
+      operationId: "test1"
+      security:
+        - bearerToken: []
+      parameters:
+        - name: "qo"
+          in: "query"
+          required: true
+          type: "string"
+
+      responses:
+        "200":
+          description: "Will send `Authenticated`"
+        "403":
+          description: "You do not have necessary permissions for the resource"
+
+  /test-2:
+    post:
+      operationId: "test2"
+      security:
+        - bearerToken: []
+      parameters:
+        - name: "body"
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/NewModel"
+
+      responses:
+        "200":
+          description: "Will send `Authenticated`"
+        "403":
+          description: "You do not have necessary permissions for the resource"
+
+definitions:
+  NewModel:
+    title: NewModel
+    type: object
+    properties:
+      id: 
+        type: string
+      name:
+        type: string
+    required:
+      - id
+      - name
+responses:
+
+parameters:
+
+consumes:
+  - application/json
+produces:
+  - application/json

--- a/e2e/src/__tests__/test-api-withDefaults/client.test.ts
+++ b/e2e/src/__tests__/test-api-withDefaults/client.test.ts
@@ -1,0 +1,41 @@
+import nodeFetch from "node-fetch";
+
+import * as E from "fp-ts/Either";
+
+import config from "../../config";
+import { createClient } from "../../generated/testapiWithDefaults/client";
+
+// @ts-ignore because leaked-handles doesn't ship type defintions
+import * as leaked from "leaked-handles";
+leaked.set({ debugSockets: true });
+
+// Use same config as
+const { skipClient } = config;
+const { isSpecEnabled, mockPort } = config.specs.testapiWithDefaults;
+
+// if there's no need for this suite in this particular run, just skip it
+const describeSuite = skipClient || !isSpecEnabled ? describe.skip : describe;
+
+describeSuite("Http client generated from Test API spec", () => {
+  it("should be a valid module", async () => {
+    expect(createClient).toBeDefined();
+    expect(createClient).toEqual(expect.any(Function));
+  });
+
+  it("should make a call, with default parameters", async () => {
+    const client = createClient<"bearerToken">({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: "",
+      // cast op to any to make it compile
+      withDefaults: op => params => op({ ...params, bearerToken: "abc123" })
+    });
+
+    expect(client.test1).toEqual(expect.any(Function));
+
+    const result = await client.test1({
+      qo: "acb123"
+    });
+    expect(result).toMatchObject(E.right({ status: 200 }));
+  });
+});

--- a/e2e/src/config.ts
+++ b/e2e/src/config.ts
@@ -49,6 +49,15 @@ export default {
       isSpecEnabled: includeInList(process.env.INCLUDE_SPECS, "testapiV3"),
       mockPort: 4103,
       url: `${ROOT_DIRECTORY_FOR_E2E}/../__mocks__/openapi_v3/api.yaml`
+    },
+    testapiWithDefaults: {
+      generatedFilesDir: `${GENERATED_BASE_DIR}/testapiWithDefaults`,
+      isSpecEnabled: includeInList(
+        process.env.INCLUDE_SPECS,
+        "testapiWithDefaults"
+      ),
+      mockPort: 4104,
+      url: `${ROOT_DIRECTORY_FOR_E2E}/../__mocks__/api_test_defaults.yaml`
     }
   }
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->

Compilation fails when withDefaults is set under the following conditions:

- The OpenAPI specification does not include any endpoint without additional parameters.
- The parameter types vary across different endpoints.

This PR introduces a new end-to-end test that replicates the failure scenario under these conditions, ensuring that the issue can be consistently reproduced for debugging and future regression testing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
e2e scenario

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
