### PR TITLE
[BREAKING CHANGE:  [IOCOM-1891] Use 3xx responses as success type fallback

### DIFF
--- a/src/commands/gen-api-models/__tests__/render.test.ts
+++ b/src/commands/gen-api-models/__tests__/render.test.ts
@@ -6,6 +6,8 @@ import * as SwaggerParser from "swagger-parser";
 import { renderDefinitionCode, renderAllOperations } from "../render";
 import { getDefinitionOrFail, getParser } from "./utils/parser.utils";
 
+import { getfirstSuccessType } from "../render";
+
 let spec: OpenAPIV2.Document;
 
 describe.each`
@@ -50,5 +52,33 @@ describe.each`
       const code = renderAllOperations([operationInfo1], true)
       expect(code).toMatchSnapshot();
     })
+});
 
+describe("getfirstSuccessType", () => {
+  it("should return the first successful response", () => {
+    const responses = [
+      { e1: "200", e2: "SuccessType", e3: [] },
+      { e1: "301", e2: "RedirectType", e3: [] }
+    ];
+    const result = getfirstSuccessType(responses);
+    expect(result).toEqual({ e1: "200", e2: "SuccessType", e3: [] });
+  });
+
+  it("should return the first redirection response if no successful response is found", () => {
+    const responses = [
+      { e1: "301", e2: "RedirectType", e3: [] },
+      { e1: "302", e2: "AnotherRedirectType", e3: [] }
+    ];
+    const result = getfirstSuccessType(responses);
+    expect(result).toEqual({ e1: "301", e2: "RedirectType", e3: [] });
+  });
+
+  it("should return undefined if no successful or redirection responses are found", () => {
+    const responses = [
+      { e1: "400", e2: "ClientErrorType", e3: [] },
+      { e1: "500", e2: "ServerErrorType", e3: [] }
+    ];
+    const result = getfirstSuccessType(responses);
+    expect(result).toBeUndefined();
+  });
 });

--- a/src/commands/gen-api-models/render.ts
+++ b/src/commands/gen-api-models/render.ts
@@ -197,6 +197,36 @@ export const renderOperation = (
 };
 
 /**
+ * Retrieves the first successful response type from a list of operation responses.
+ *
+ * This function iterates through the provided responses and checks the status code.
+ * If a response has a status code starting with "2" (indicating success), it returns that response.
+ * If no such response is found, it checks for responses with status codes starting with "3" (indicating redirection).
+ * If any redirection responses are found, it returns the first one.
+ * If neither successful nor redirection responses are found, it returns `undefined`.
+ *
+ * @param responses - An array of operation responses to evaluate.
+ * @returns The first successful response, the first redirection response if no successful response is found, or `undefined` if neither are found.
+ */
+export const getfirstSuccessType = (
+  responses: IOperationInfo["responses"]
+): IOperationInfo["responses"][number] | undefined => {
+  const redirectResponses = [];
+  for (const response of responses) {
+    if (response.e1.length === 3) {
+      if (response.e1[0] === "2") {
+        return response;
+      }
+      if (response.e1[0] === "3") {
+        // eslint-disable-next-line functional/immutable-data
+        redirectResponses.push(response);
+      }
+    }
+  }
+  return redirectResponses.length > 0 ? redirectResponses[0] : undefined;
+};
+
+/**
  * Compose the code for response decoder of an operation
  *
  * @param operationInfo the operation
@@ -206,9 +236,7 @@ export const renderOperation = (
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, prefer-arrow/prefer-arrow-functions
 export function renderDecoderCode({ responses, operationId }: IOperationInfo) {
   // use the first 2xx type as "success type" that we allow to be overridden
-  const firstSuccessType = responses.find(
-    ({ e1 }) => e1.length === 3 && e1[0] === "2"
-  );
+  const firstSuccessType = getfirstSuccessType(responses);
   if (!firstSuccessType) {
     return "";
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
Now `renderDecoderCode`, if no `2xx` response is found, checks for responses with status codes starting with "3" (indicating redirection).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `gen-api-models` command expects each endpoint to have at least one successful (`2xx`) response - this is not always true, because some endpoints can returns a redirection response (`3xx`) on success.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
